### PR TITLE
Compare Go versions numerically

### DIFF
--- a/hack/lib/build/binaries.sh
+++ b/hack/lib/build/binaries.sh
@@ -85,7 +85,9 @@ function os::build::setup_env() {
   if [[ "${TRAVIS:-}" != "true" ]]; then
     local go_version
     go_version=($(go version))
-    if [[ "${go_version[2]}" < "${OS_REQUIRED_GO_VERSION}" ]]; then
+    local expected_order=$(printf "%s\n%s\n" "${OS_REQUIRED_GO_VERSION}" "${go_version[2]}")
+    local actual_order=$(echo "${expected_order}" | sort --version-sort)
+    if [[ "${actual_order}" != "${expected_order}" ]]; then
       os::log::fatal "Detected Go version: ${go_version[*]}.
 Builds require Go version ${OS_REQUIRED_GO_VERSION} or greater."
     fi


### PR DESCRIPTION
This is a backport of https://github.com/openshift/release/pull/713

Original commit message:

Currently the `setup_env` function compares the required and available
Go versions alphabetically.  This doesn't work correctly when comparing
1.9 and 1.10. As a result it isn't possible to build with Go 1.10. To
avoid that issue this patch changes the function so that it compares the
versions numerically, using the `--version-sort` option of the `sort`
command.