### PR TITLE
Add alerts prefix to alerts endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,25 @@ awxJob:
     }
 ```
 
+## Testing
+
+To run the automated tests of the project run this command:
+
+```
+$ make check
+```
+
+To manually test the service, without having to have a running Prometheus alert
+manager that generates the alert notifications, you can use the `*-alert.json`
+files that are inside the `manifests` directory. For example, to simulate the
+`NodeDown` alert start the server and then use [curl](https://curl.haxx.se) to
+send the alert notification:
+
+```
+$ autoheal server --config-file=my.yml --logtostderr
+$ curl --data @manifests/node-down-alert.json http://localhost:9099/alerts
+```
+
 ## Building
 
 To build the binary run this command:

--- a/cmd/autoheal/healer.go
+++ b/cmd/autoheal/healer.go
@@ -152,7 +152,7 @@ func (h *Healer) Run(stopCh <-chan struct{}) error {
 
 	// Start the web server:
 	http.Handle("/metrics", promhttp.Handler())
-	http.HandleFunc("/", h.handleRequest)
+	http.HandleFunc("/alerts", h.handleRequest)
 
 	server := &http.Server{Addr: ":9099"}
 	go server.ListenAndServe()


### PR DESCRIPTION
Currently the auto-heal service accepts alert notifications with any
request path, except with `metrics` because that is used to report
metrics to Prometheus. That could cause problems if in the future we
want to add other endpoints. To avoid that this patch changes the
service so that it will only accept alerts that use the `/alerts` prefix
in the request path.

Note that this means that in order to manually test you will have to
explicitly add the `/alerts` prefix:

```
$ autoheal server --config-file=my.yml --logtostderr
$ curl --data @manifests/node-down-alert.json http://localhost:9099/alerts
```