### PR TITLE
Return error if failed to obtain auth token

### DIFF
--- a/pkg/awx/connection.go
+++ b/pkg/awx/connection.go
@@ -195,6 +195,9 @@ func (c *Connection) getToken() error {
 	if err != nil {
 		return err
 	}
+	if len(response.Token) == 0 {
+		return fmt.Errorf("Error obtaining auth token")
+	}
 	c.token = response.Token
 	return nil
 }


### PR DESCRIPTION
In some cases, we fail to get the auth token, and continue to additional
requests that will fail. It is evident when using verbosity level 2:

```
connection.go:305] Sending POST request to 'http://localhost:9100/api/v2/authtoken/'.
connection.go:306] Request body:
{
  "username": "admin",
  "password": "password"
}
connection.go:330] Response body:
{
  "detail": "The requested resource could not be found."
}
connection.go:252] Sending GET request to 'http://localhost:9100/api/v2/job_templates/?name=Start+node&project__name=My+project'.
connection.go:274] Response body:
{
  "detail": "Authentication credentials were not provided."
}
```

Now we raise an error in those cases, and do not try any longer:
```
connection.go:305] Sending POST request to 'http://localhost:9100/api/v2/authtoken/'.
connection.go:306] Request body:
{
  "username": "admin",
  "password": "password"
}
connection.go:330] Response body:
{
  "detail": "The requested resource could not be found."
}
alerts_worker.go:62] Error obtaining auth token
```