### PR TITLE
Return error when awx requests fail

### DIFF
--- a/pkg/awx/connection.go
+++ b/pkg/awx/connection.go
@@ -260,6 +260,14 @@ func (c *Connection) rawGet(path string, query url.Values) (output []byte, err e
 	if err != nil {
 		return
 	}
+	if response.StatusCode != 200 {
+		err = fmt.Errorf(
+			"Status code '%d' returned from server: '%s'",
+			response.StatusCode,
+			response.Status,
+		)
+		return
+	}
 	body := response.Body
 	defer body.Close()
 
@@ -313,6 +321,14 @@ func (c *Connection) rawPost(path string, query url.Values, input []byte) (outpu
 	c.setAccept(request)
 	response, err := c.client.Do(request)
 	if err != nil {
+		return
+	}
+	if response.StatusCode != 200 {
+		err = fmt.Errorf(
+			"Status code '%d' returned from server: '%s'",
+			response.StatusCode,
+			response.Status,
+		)
 		return
 	}
 	body := response.Body


### PR DESCRIPTION
See https://github.com/openshift/autoheal/pull/23 for cases where we swallow errors.
This is a more general solution to that problem

```
Sending POST request to 'http://localhost:9100/api/v2/authtoken/'.
connection.go:313] Request body:
{
  "username": "admin",
  "password": "password"
}
alerts_worker.go:62] Status code '404' returned from server: '404 Not Found'
```