### PR TITLE
Avoid `logging before flag.Parse`

### DIFF
--- a/cmd/autoheal/main.go
+++ b/cmd/autoheal/main.go
@@ -37,6 +37,12 @@ func init() {
 }
 
 func main() {
+	// This is needed to make `glog` believe that the flags have already been parsed, otherwise
+	// every log messages is prefixed by an error message stating the the flags haven't been
+	// parsed.
+	flag.CommandLine.Parse([]string{})
+
+	// Execute the root command:
 	rootCmd.SetArgs(os.Args[1:])
 	rootCmd.Execute()
 }


### PR DESCRIPTION
That message is printed before every log message because `glog` thinks
that the command line hasn't been parsed:

```
ERROR: logging before flag.Parse: ...
```

The command line has actually been parsed, but by the `pflag` package,
not by the `flag` package. To avoid that, this pull request changes the main
program so that it parses a dummy empty command line, which makes `glog`
happy.