### PR TITLE
Healing action throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,32 @@ should always be set to `false` (the default) in production environments.
 The `project` parameter is the name of the AWX project that contains the job
 templates that will be used to run the playbooks.
 
+### Throttling configuration
+
+The `throttling` section of the configuration describes how to throttle the
+execution of healing actions. This is intended to prevent _healing storms_ that
+could happen if the same alerts are send repeatedly to the service.
+
+The `interval` parameter controls the time that the service will remember an
+executed healing action. If an action is triggered more than once in the given
+interval it will be executed only the first time. The rest of the times it will
+be logged and ignored. (see `autoheal.yml` for an example.)
+
+The default interval value is one hour. Leaving the `interval` parameter 0
+will *disable* throttling altogether.
+
+Note that for throttling purposes actions are considered the same if they
+have exactly the same fields with exactly the same values *after* processing
+them as templates. For example, an action defined like this:
+
+```yaml
+awxJob:
+  template: "Restart {{ $labels.service }}"
+``
+
+Will have different values for the `template` field if the triggering alerts
+have different `service` labels.
+
 ### Healing rules configuration
 
 The second important section of the configuration file is `rules`. It contains

--- a/autoheal.yml
+++ b/autoheal.yml
@@ -63,6 +63,30 @@ awx:
   project: "My project"
 
 #
+# This section describes how to throttle the execution of healing rules.
+throttling:
+  #
+  # The time that the service will remember an executed healing action. If an
+  # action is triggered more than once in the given interval it will be executed
+  # only the first time. The rest of the times it will be logged and ignored.
+  #
+  # Note that for throttling purposes actions are considered the same if they
+  # have exactly the same fields with exactly the same values *after* processing
+  # them as templates.  For example, an action defined like this:
+  #
+  #   awxJob:
+  #     template: "Restart {{ $labels.service }}"
+  #
+  # Will have different values for the `template` field if the triggering alerts
+  # have different `service` labels.
+  #
+  # Interval is a duration string ,that is, a sequence of decimal numbers,
+  # each with optional fraction and a unit suffix, such as "300ms" or "2h45m".
+  # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". (For more details see https://golang.org/pkg/time/#Duration)
+  #
+  interval: 1h
+
+#
 # This section contains the healing rules.
 #
 rules:

--- a/cmd/autoheal/healer.go
+++ b/cmd/autoheal/healer.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/openshift/autoheal/pkg/alertmanager"
 	"github.com/openshift/autoheal/pkg/config"
+	"github.com/openshift/autoheal/pkg/memory"
 )
 
 // HealerBuilder is used to create new healers.
@@ -64,6 +65,9 @@ type Healer struct {
 	// notifications from the alert manager:
 	rulesQueue  workqueue.RateLimitingInterface
 	alertsQueue workqueue.RateLimitingInterface
+
+	// Executed actions will be stored here in order to prevent repeated execution.
+	actionMemory *memory.ShortTermMemory
 }
 
 // NewHealerBuilder creates a new builder for healers.
@@ -119,10 +123,19 @@ func (b *HealerBuilder) Build() (h *Healer, err error) {
 	glog.Infof("AWX user is '%s'", config.AWX().User())
 	glog.Infof("AWX project is '%s'", config.AWX().Project())
 
+	// Create the actions memory:
+	actionMemory, err := memory.NewShortTermMemoryBuilder().
+		Duration(config.Throttling().Interval()).
+		Build()
+	if err != nil {
+		return
+	}
+
 	// Allocate the healer:
 	h = new(Healer)
 	h.k8sClient = b.k8sClient
 	h.config = config
+	h.actionMemory = actionMemory
 
 	// Initialize the map of rules:
 	h.rulesCache = new(syncmap.Map)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,14 +19,24 @@ limitations under the License.
 package config
 
 import (
+	"time"
+
 	monitoring "github.com/openshift/autoheal/pkg/apis/monitoring/v1alpha1"
 )
 
 // Config is a read only view of the configuration of the auto-heal service.
 //
 type Config struct {
-	awx   *AWXConfig
-	rules []*monitoring.HealingRule
+	awx        *AWXConfig
+	throttling *ThrottlingConfig
+	rules      []*monitoring.HealingRule
+}
+
+// ThrottlingConfig is a read only view of the section of the configuration that describes how to
+// throttle the execution of healing rules.
+//
+type ThrottlingConfig struct {
+	interval time.Duration
 }
 
 // AWX is a read only view of section of the configuration of the auto-heal service that describes
@@ -99,6 +109,20 @@ func (c *AWXConfig) Project() string {
 //
 func (c *AWXConfig) Insecure() bool {
 	return c.insecure
+}
+
+// Throttling returns a read only view of the section of the configuration that describes how to
+// throttle the execution of healing rules.
+//
+func (c *Config) Throttling() *ThrottlingConfig {
+	return c.throttling
+}
+
+// Interval returns the throttling interval for the execution of the actions defined in the healing
+// rules.
+//
+func (t *ThrottlingConfig) Interval() time.Duration {
+	return t.interval
 }
 
 // Rules returns the list of healing rules defined in the configuration.

--- a/pkg/internal/data/config.go
+++ b/pkg/internal/data/config.go
@@ -31,6 +31,9 @@ type Config struct {
 	// AWX contains the details to connect to the default AWX server.
 	AWX *AWXConfig `json:"awx,omitempty"`
 
+	// Throttling contains the healing rule execution throttling details.
+	Throttling *ThrottlingConfig
+
 	// The list of healing rules.
 	Rules []*monitoring.HealingRule `json:"rules,omitempty"`
 }
@@ -58,4 +61,11 @@ type AWXConfig struct {
 
 	// Project is the name of the AWX project that contains the job templates.
 	Project string `json:"project,omitempty"`
+}
+
+// ThrottlingConfig is used to mardhal and unmarshal the healing rule exeuction throttling
+// configuration.
+//
+type ThrottlingConfig struct {
+	Interval string `json:"interval,omitempty"`
 }

--- a/pkg/memory/doc.go
+++ b/pkg/memory/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This package contains types and functions useful for managing data that needs to be remembered.
+//
+package memory

--- a/pkg/memory/short_term.go
+++ b/pkg/memory/short_term.go
@@ -1,0 +1,159 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file contains the implementation of the memory where the healer stores the list of actions
+// that have already been performed.
+
+package memory
+
+import (
+	"reflect"
+	"sync"
+	"time"
+)
+
+// ShortTermMemoryBuilder builds of short term memory objects.
+//
+type ShortTermMemoryBuilder struct {
+	// How long to remember actions.
+	duration time.Duration
+}
+
+// ShortTermMemory stores a set of items for a given period of time.
+//
+type ShortTermMemory struct {
+	// How long to remember actions.
+	duration time.Duration
+
+	// There will be a cell for each action stored, containing the action itself and the time it was
+	// added to the memory.
+	cells []*ShortTermCell
+
+	// Mutex used to prevent simultaneous updates of the data structures.
+	mutex *sync.Mutex
+}
+
+// ShortTermCell stores each individual action, and the time it was added to the memory.
+//
+type ShortTermCell struct {
+	// The item stored in the cell.
+	item interface{}
+
+	// The time when the cell was created or updated.
+	stamp time.Time
+}
+
+// NewShortTermMemoryBuilder creates a builder that can create short term memory objects.
+//
+func NewShortTermMemoryBuilder() *ShortTermMemoryBuilder {
+	b := new(ShortTermMemoryBuilder)
+	return b
+}
+
+// Duration sets how long objects in the memory will be remembered. The default is zero, which means
+// that objects won't be remembered at all.
+//
+func (b *ShortTermMemoryBuilder) Duration(duration time.Duration) *ShortTermMemoryBuilder {
+	b.duration = duration
+	return b
+}
+
+// Build creates a new short term memory object with the configuration stored in the builder.
+//
+func (b *ShortTermMemoryBuilder) Build() (m *ShortTermMemory, err error) {
+	m = new(ShortTermMemory)
+	m.duration = b.duration
+	m.cells = make([]*ShortTermCell, 0)
+	m.mutex = &sync.Mutex{}
+	return
+}
+
+// Add adds a new item to the memory.
+//
+func (m *ShortTermMemory) Add(item interface{}) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	cell := m.findMatchingCell(item)
+	if cell == nil {
+		cell = new(ShortTermCell)
+		cell.item = item
+		m.cells = append(m.cells, cell)
+	}
+	cell.stamp = time.Now()
+}
+
+func (m *ShortTermMemory) Has(item interface{}) bool {
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	// Purge cells before checking.
+	m.purgeExpiredCells()
+	return m.findMatchingCell(item) != nil
+}
+
+// Len returns the number of items inside the memory.
+//
+func (m *ShortTermMemory) Len() int {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.purgeExpiredCells()
+	return len(m.cells)
+}
+
+// purgeExpiredCells finds the aged cells and removes them.
+//
+func (m *ShortTermMemory) purgeExpiredCells() {
+	// The cells in ShortTermMemory are monotonously increasing - from "older" to "younger"
+	// thus, it suffices to check for until age < duration and then - break.
+	now := time.Now()
+	for idx, cell := range m.cells {
+		age := now.Sub(cell.stamp)
+		if age >= m.duration {
+			// zeroing the value of the cell so that it wouldn't be refrenced by the underlying array
+			// causing GO's grabage collector to collect the allocated memory.
+			m.cells[idx] = nil
+			m.cells = append(m.cells[:idx], m.cells[idx+1:]...)
+		} else {
+			break
+		}
+	}
+}
+
+// findMatchingCell tries to find the cell that contains the given item and returs a pointer to that
+// cell or else nil if no such cell exists. Note that this method assumes that the mutex has already
+// been acquired and that the expired cells have already been purged.
+//
+func (m *ShortTermMemory) findMatchingCell(item interface{}) *ShortTermCell {
+	for _, cell := range m.cells {
+		if reflect.DeepEqual(item, cell.item) {
+			return cell
+		}
+	}
+	return nil
+}
+
+func (m *ShortTermMemory) Duration() time.Duration {
+	return m.duration
+}
+
+// Purge the expired cells from the short term memory cache.
+//
+func (m *ShortTermMemory) Clean() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.purgeExpiredCells()
+}

--- a/pkg/memory/short_term_test.go
+++ b/pkg/memory/short_term_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"testing"
+	"time"
+
+	monitoring "github.com/openshift/autoheal/pkg/apis/monitoring/v1alpha1"
+)
+
+func TestExisting(t *testing.T) {
+	memory := makeMemory(t, 1*time.Millisecond)
+	action := &monitoring.AWXJobAction{
+		Template: "My template",
+	}
+	memory.Add(action)
+	if !memory.Has(action) {
+		t.Fail()
+	}
+}
+
+func TestNotExisting(t *testing.T) {
+	memory := makeMemory(t, 1*time.Millisecond)
+	action := &monitoring.AWXJobAction{
+		Template: "My template",
+	}
+	if memory.Has(action) {
+		t.Fail()
+	}
+}
+
+func TestSameTemplate(t *testing.T) {
+	memory := makeMemory(t, 1*time.Millisecond)
+	first := &monitoring.AWXJobAction{
+		Template: "My template",
+	}
+	second := &monitoring.AWXJobAction{
+		Template: "My template",
+	}
+	memory.Add(first)
+	if !memory.Has(first) {
+		t.Fail()
+	}
+	if !memory.Has(second) {
+		t.Fail()
+	}
+}
+
+func TestDifferentTemplate(t *testing.T) {
+	memory := makeMemory(t, 1*time.Millisecond)
+	first := &monitoring.AWXJobAction{
+		Template: "My template",
+	}
+	second := &monitoring.AWXJobAction{
+		Template: "Your template",
+	}
+	memory.Add(first)
+	if !memory.Has(first) {
+		t.Fail()
+	}
+	if memory.Has(second) {
+		t.Fail()
+	}
+}
+
+func TestSameVars(t *testing.T) {
+	memory := makeMemory(t, 1*time.Millisecond)
+	first := &monitoring.AWXJobAction{
+		ExtraVars: `{
+			"myvar": "myvalue"
+		}`,
+	}
+	second := &monitoring.AWXJobAction{
+		ExtraVars: `{
+			"myvar": "myvalue"
+		}`,
+	}
+	memory.Add(first)
+	if !memory.Has(first) {
+		t.Fail()
+	}
+	if !memory.Has(second) {
+		t.Fail()
+	}
+}
+
+func TestDifferentVars(t *testing.T) {
+	memory := makeMemory(t, 1*time.Millisecond)
+	first := &monitoring.AWXJobAction{
+		ExtraVars: `{
+			"myvar": "myvalue"
+		}`,
+	}
+	second := &monitoring.AWXJobAction{
+		ExtraVars: `{
+			"yourvar": "yourvalue"
+		}`,
+	}
+	memory.Add(first)
+	if !memory.Has(first) {
+		t.Fail()
+	}
+	if memory.Has(second) {
+		t.Fail()
+	}
+}
+
+func TestExpired(t *testing.T) {
+	memory := makeMemory(t, 1*time.Millisecond)
+	action := &monitoring.AWXJobAction{
+		Template: "My template",
+	}
+	memory.Add(action)
+	if !memory.Has(action) {
+		t.Fail()
+	}
+	time.Sleep(2 * time.Millisecond)
+	if memory.Has(action) {
+		t.Fail()
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	memory := makeMemory(t, 1*time.Millisecond)
+	action := &monitoring.AWXJobAction{
+		Template: "My template",
+	}
+	memory.Add(action)
+	time.Sleep(900 * time.Nanosecond)
+	memory.Add(action)
+	time.Sleep(200 * time.Nanosecond)
+	if !memory.Has(action) {
+		t.Fail()
+	}
+}
+
+func TestLen(t *testing.T) {
+	memory := makeMemory(t, 1*time.Millisecond)
+	first := &monitoring.AWXJobAction{
+		Template: "My template",
+	}
+	memory.Add(first)
+	if memory.Len() != 1 {
+		t.Fail()
+	}
+	second := &monitoring.AWXJobAction{
+		Template: "Your template",
+	}
+	memory.Add(second)
+	if memory.Len() != 2 {
+		t.Fail()
+	}
+}
+
+func TestLenExpired(t *testing.T) {
+	memory := makeMemory(t, 1*time.Millisecond)
+	action := &monitoring.AWXJobAction{
+		Template: "My template",
+	}
+	memory.Add(action)
+	time.Sleep(2 * time.Millisecond)
+	if memory.Len() != 0 {
+		t.Fail()
+	}
+}
+
+func makeMemory(t *testing.T, duration time.Duration) *ShortTermMemory {
+	memory, err := NewShortTermMemoryBuilder().
+		Duration(duration).
+		Build()
+	if err != nil {
+		t.Error(err)
+	}
+	return memory
+}


### PR DESCRIPTION
This patch adds a mechanism to throttle the execution of healing
actions. A new `throttling` section will be added to the configuration
file:

```yaml
throttling:
  interval: 1h
```

The new `interval` parameter controls for how long are executed healing
actions remembered. If the same healing action is triggered a second
time within this interval it won't be executed.