### PR TITLE
Expose a metric on launched AWX jobs

### DIFF
--- a/cmd/autoheal/awx_job.go
+++ b/cmd/autoheal/awx_job.go
@@ -82,7 +82,7 @@ func (h *Healer) runAWXJob(rule *monitoring.HealingRule, action *monitoring.AWXJ
 		alert.Name(),
 	)
 	for _, template := range templatesResponse.Results() {
-		err := h.launchAWXJob(connection, template, action)
+		err := h.launchAWXJob(connection, template, action, rule)
 		if err != nil {
 			return err
 		}
@@ -91,7 +91,12 @@ func (h *Healer) runAWXJob(rule *monitoring.HealingRule, action *monitoring.AWXJ
 	return nil
 }
 
-func (h *Healer) launchAWXJob(connection *awx.Connection, template *awx.JobTemplate, action *monitoring.AWXJobAction) error {
+func (h *Healer) launchAWXJob(
+	connection *awx.Connection,
+	template *awx.JobTemplate,
+	action *monitoring.AWXJobAction,
+	rule *monitoring.HealingRule,
+) error {
 	templateId := template.Id()
 	templateName := template.Name()
 	launchResource := connection.JobTemplates().Id(templateId).Launch()
@@ -105,5 +110,6 @@ func (h *Healer) launchAWXJob(connection *awx.Connection, template *awx.JobTempl
 		"Request to launch AWX job from template '%s' has been sent",
 		templateName,
 	)
+	h.incrementAwxActions(action, rule.ObjectMeta.Name)
 	return nil
 }

--- a/cmd/autoheal/healer.go
+++ b/cmd/autoheal/healer.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/sync/syncmap"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -151,7 +150,7 @@ func (h *Healer) Run(stopCh <-chan struct{}) error {
 	}
 
 	// Start the web server:
-	http.Handle("/metrics", promhttp.Handler())
+	http.Handle("/metrics", h.metricsHandler())
 	http.HandleFunc("/alerts", h.handleRequest)
 
 	server := &http.Server{Addr: ":9099"}

--- a/cmd/autoheal/metrics_exporter.go
+++ b/cmd/autoheal/metrics_exporter.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"net/http"
+
+	monitoring "github.com/openshift/autoheal/pkg/apis/monitoring/v1alpha1"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	actionsInitiated = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "autoheal_actions_initiated_total",
+			Help: "Number of initiated healing actions",
+		},
+		[]string{"type", "template", "rule"},
+	)
+)
+
+func (h *Healer) metricsHandler() http.Handler {
+	return promhttp.Handler()
+}
+
+func (h *Healer) initExportedMetrics() {
+	prometheus.MustRegister(actionsInitiated)
+}
+
+func (h *Healer) incrementAwxActions(
+	action *monitoring.AWXJobAction,
+	ruleName string,
+) {
+	actionsInitiated.With(
+		map[string]string{
+			"type":     "awxJob",
+			"template": action.Template,
+			"rule":     ruleName,
+		},
+	).Inc()
+}

--- a/cmd/autoheal/server.go
+++ b/cmd/autoheal/server.go
@@ -116,6 +116,9 @@ func serverRun(cmd *cobra.Command, args []string) {
 		glog.Fatalf("Error building healer: %s", err.Error())
 	}
 
+	// Register exported metrics:
+	healer.initExportedMetrics()
+
 	// Run the healer:
 	if err = healer.Run(stopCh); err != nil {
 		glog.Fatalf("Error running healer: %s", err.Error())

--- a/documentation/metrics.md
+++ b/documentation/metrics.md
@@ -1,0 +1,31 @@
+# Metrics
+
+autoheal uses [Prometheus](https://prometheus.io/) for metrics reporting. The metrics can be used for real-time monitoring and debugging. The auto-heal service does not persist its metrics; the metrics will be reset upon restart.
+
+The simplest way to see the available metrics is to cURL the metrics endpoint `/metrics`. The format is described [here](http://prometheus.io/docs/instrumenting/exposition_formats/).
+
+Follow the [Prometheus getting started doc](https://prometheus.io/docs/prometheus/latest/getting_started/) to spin up a Prometheus server to collect autoheal metrics.
+
+The naming of metrics follows the suggested [Prometheus best practices](http://prometheus.io/docs/practices/naming/). A metric name has an `autoheal`, `go` or `process` prefix as its namespace and a subsystem prefix.
+
+## Autoheal namespace metrics
+
+The metrics under the `autoheal` prefix expose information related to healing actions undertaken by the server
+
+### Actions
+
+These metrics describe the status of healing actions attempted by the server.
+
+All these metrics are prefixed with `autoheal_actions_`
+
+| Name             | Description                         | Type    |
+|------------------|-------------------------------------|---------|
+| initiated_total  | Number of initiated healing actions | Counter |
+
+`initiated_total` indicates how many healing actions were successfully kicked off by the server. An AWX type action is counted when a SUCCESSFUL `launch` request was done against an AWX server.
+
+## Prometheus supplied metrics
+
+The Prometheus client library provides a number of metrics under the `go` and `process` namespaces that pertain to the entire process and the go runtime of the entire process. To find out more about these, see:
+[go-collector](https://github.com/prometheus/client_golang/blob/master/prometheus/go_collector.go),
+[process_collector](https://github.com/prometheus/client_golang/blob/master/prometheus/process_collector.go)


### PR DESCRIPTION
An example of the exposed metric after running one `start-node` job and two `SAY_HELLO` jobs:

```
# HELP autoheal_actions_initiated_total Number of initiated healing actions
# TYPE autoheal_actions_initiated_total counter
autoheal_actions_initiated_total{rule="say-hello",template="SAY_HELLO",type="awxJob"} 2
autoheal_actions_initiated_total{rule="start-node",template="Start node",type="awxJob"} 1
```