### PR TITLE
Secure connection by default between autoheal and AWX

### DIFF
--- a/autoheal.yml
+++ b/autoheal.yml
@@ -51,6 +51,13 @@ awx:
     name: my-awx-tls
 
   #
+  # Whether to use an insecure connection to the AWX server
+  # this should always be set to false in production,
+  # but can be set to true when developing. Defaults to false.
+  #
+  insecure: false
+
+  #
   # The name of the AWX project that contains the auto-heal job templates.
   #
   project: "My project"

--- a/cmd/autoheal/awx_job.go
+++ b/cmd/autoheal/awx_job.go
@@ -34,6 +34,8 @@ func (h *Healer) runAWXJob(rule *monitoring.HealingRule, action *monitoring.AWXJ
 	awxProxy := h.config.AWX().Proxy()
 	awxUser := h.config.AWX().User()
 	awxPassword := h.config.AWX().Password()
+	awxCA := h.config.AWX().CA()
+	awxInsecure := h.config.AWX().Insecure()
 
 	// Get the name of the AWX project name from the configuration:
 	awxProject := h.config.AWX().Project()
@@ -47,7 +49,8 @@ func (h *Healer) runAWXJob(rule *monitoring.HealingRule, action *monitoring.AWXJ
 		Proxy(awxProxy).
 		Username(awxUser).
 		Password(awxPassword).
-		Insecure(true).
+		CACertificates(awxCA).
+		Insecure(awxInsecure).
 		Build()
 	if err != nil {
 		return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,7 @@ type AWXConfig struct {
 	proxy    string
 	user     string
 	password string
+	insecure bool
 	ca       []byte
 	project  string
 }
@@ -82,7 +83,7 @@ func (c *AWXConfig) Password() string {
 }
 
 // CA returns the PEM encoded certificates of the authorities that should be trusted when checking
-// the TLS certificate presented by the AWX server.
+// the TLS certificate presented by the AWX server. If not provided the system cert pool will be used.
 //
 func (c *AWXConfig) CA() []byte {
 	return c.ca
@@ -92,6 +93,12 @@ func (c *AWXConfig) CA() []byte {
 //
 func (c *AWXConfig) Project() string {
 	return c.project
+}
+
+// Whether to use insecure connection to connect to AWX.
+//
+func (c *AWXConfig) Insecure() bool {
+	return c.insecure
 }
 
 // Rules returns the list of healing rules defined in the configuration.

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -161,6 +161,9 @@ func (l *Loader) mergeAWX(decoded *data.AWXConfig) error {
 		}
 	}
 
+	// Merge insecure setting:
+	l.config.awx.insecure = decoded.Insecure
+
 	// Merge the project:
 	if decoded.Project != "" {
 		l.config.awx.project = decoded.Project

--- a/pkg/internal/data/config.go
+++ b/pkg/internal/data/config.go
@@ -53,6 +53,9 @@ type AWXConfig struct {
 	// certificates and keys used to access the AWX API.
 	TLSRef *core.SecretReference `json:"tlsRef,omitempty"`
 
+	// Whether to use an insecure connection to connect to AWX.
+	Insecure bool `json:"insecure,omitempty"`
+
 	// Project is the name of the AWX project that contains the job templates.
 	Project string `json:"project,omitempty"`
 }


### PR DESCRIPTION
This commit adds support for setting the CA root cert in the AWX
client, and defaults to validating this cert.

If no root cert is specified, the system trust store will be used.

To retain the "insecure" option (the previous default),
for use for development, a new "insecure" option was added
to the configuration file

I haven't tested this all the way through as I don't have an autoheal/awx environment properly set up at the moment. Please consider that before merging.

cc: @jhernand @nimrodshn @moolitayer 