### PR TITLE
Add support for multiple configuration files

### DIFF
--- a/cmd/autoheal/healer.go
+++ b/cmd/autoheal/healer.go
@@ -81,6 +81,18 @@ func (b *HealerBuilder) ConfigFile(path string) *HealerBuilder {
 	return b
 }
 
+// ConfigFiles adds one or more configuration files or directories. They will be loaded in the order
+// given. For directories all the contained files will be loaded, in alphabetical order.
+//
+func (b *HealerBuilder) ConfigFiles(paths []string) *HealerBuilder {
+	if len(paths) > 0 {
+		for _, path := range paths {
+			b.ConfigFile(path)
+		}
+	}
+	return b
+}
+
 // KubernetesClient sets the Kubernetes client that will be used by the healer.
 //
 func (b *HealerBuilder) KubernetesClient(client kubernetes.Interface) *HealerBuilder {

--- a/cmd/autoheal/server.go
+++ b/cmd/autoheal/server.go
@@ -34,7 +34,7 @@ import (
 var (
 	serverKubeAddress string
 	serverKubeConfig  string
-	serverConfigFile  string
+	serverConfigFiles []string
 )
 
 var serverCmd = &cobra.Command{
@@ -60,11 +60,15 @@ func init() {
 		"The address of the Kubernetes API server. Overrides any value in the Kubernetes "+
 			"configuration file. Only required when running outside of a cluster.",
 	)
-	serverFlags.StringVar(
-		&serverConfigFile,
+	serverFlags.StringSliceVar(
+		&serverConfigFiles,
 		"config-file",
-		"autoheal.yml",
-		"The location of the configuration file.",
+		[]string{"autoheal.yml"},
+		"The location of the configuration file. Can be used multiple times to specify "+
+			"multiple configuration files or directories. They will be loaded in the "+
+			"same order that they appear in the command line. When the value is a "+
+			"directory all the files inside whose names end in .yml or .yaml will be "+
+			"loaded, in alphabetical order.",
 	)
 }
 
@@ -109,7 +113,7 @@ func serverRun(cmd *cobra.Command, args []string) {
 
 	// Build the healer:
 	healer, err := NewHealerBuilder().
-		ConfigFile(serverConfigFile).
+		ConfigFiles(serverConfigFiles).
 		KubernetesClient(k8sClient).
 		Build()
 	if err != nil {


### PR DESCRIPTION
Currently the configuration of the server is loaded from one single
file. This patch adds support for using multiple files and directories.
For example, the AWX configuration can be stored in a `awx.yml` file and
the rules can be stored in separate files inside the `rules.d`
directory:

```
autoheal server --config-file=awx.yml --config-file=rules.d
```

This is very convenient for situations where different parts of the
configuration are owned by different persons or teams, as they can be
stored in different places and with different permissions.