### PR TITLE
Document the `awx.insecure` parameter in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ data:
     ...
 ```
 
+The `insecure` parameter controls whether to use an insecure connection to the
+AWX server. If the connection is insecure then the TLS will not be verified. It
+should always be set to `false` (the default) in production environments.
+
 The `project` parameter is the name of the AWX project that contains the job
 templates that will be used to run the playbooks.
 

--- a/autoheal.yml
+++ b/autoheal.yml
@@ -51,9 +51,9 @@ awx:
     name: my-awx-tls
 
   #
-  # Whether to use an insecure connection to the AWX server
-  # this should always be set to false in production,
-  # but can be set to true when developing. Defaults to false.
+  # Whether to use an insecure connection to the AWX server this should always
+  # be set to `false` in production, but can be set to `true` when developing.
+  # Defaults to `false`.
   #
   insecure: false
 


### PR DESCRIPTION
This patch adds a paragraph to the `README.md` file explaining the
meaning of the `awx.insecure` parameter, mostly copied from the comment
in the configuration file.