### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ them as templates. For example, an action defined like this:
 ```yaml
 awxJob:
   template: "Restart {{ $labels.service }}"
-``
+```
 
 Will have different values for the `template` field if the triggering alerts
 have different `service` labels.


### PR DESCRIPTION
This patch adds a missing block closing line which made the `README.md` look
incorrect when rendered as HTML.