### PR TITLE
Send alert log only when using --v=2

### DIFF
--- a/cmd/autoheal/healer.go
+++ b/cmd/autoheal/healer.go
@@ -208,7 +208,9 @@ func (h *Healer) handleRequest(response http.ResponseWriter, request *http.Reque
 	}
 
 	// Dump the request to the log:
-	glog.Infof("Request body:\n%s", h.indent(body))
+	if glog.V(2) {
+		glog.Infof("Request body:\n%s", h.indent(body))
+	}
 
 	// Parse the JSON request body:
 	message := new(alertmanager.Message)


### PR DESCRIPTION
Currently we dump the bodies of the requests received from the alert
manager by default. This makes the log too verbose. This patch changes
the healer so that it do this only when the log verbosity level is set
to at least 2.