### PR TITLE
Make secrets optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,36 @@ data:
   password: ...
 ```
 
+Alternatively it is also possible to specify the user name and password directly
+inside the configuration file, using the `credentials` section. For example:
+
+```yaml
+credentials:
+  username: autoheal
+  password: ...
+```
+
+This is very convenient for development environments, but it is not recommended
+for production environments, as then the configuration file needs to be
+protected very carefully. For example, you can create a separate file for the
+credentials, give it restricted permissions, and then load it using the
+`--config-file` option twice:
+
+```
+$ echo > general.yml <<.
+awx:
+  address: https://myawx.example.com/api
+.
+$ echo > credentials.yml <<.
+credentials:
+  username: "autoheal"
+  password: "..."
+.
+$ chmod u=r,g=,o= credentials.yml
+$ autoheal server --config-file=general.yml --config-file=credentials.yml
+
+```
+
 The `tlsRef` parameter is a reference to the [Kubernetes
 secret](https://kubernetes.io/docs/concepts/configuration/secret) that contains
 the certificates used to connect to the AWX API. That secret should contain the
@@ -95,6 +125,27 @@ data:
     LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMvVENDQWVXZ0F3SUJBZ0lKQUxNRXB6OWxa
     VkVzdzI3Sm5BYlMyejNhbUF0YTc1QmNnVGcvOUFCdDV0VVc2VTJOKzkKbXc9PQotLS0tLUVORCBD
     ...
+```
+
+Alternatively it is also possible to specify the CA certificates directly inside
+the configuration file, using the `tls` section. For example:
+
+```yaml
+tls:
+  caCerts: |-
+    -----BEGIN CERTIFICATE-----
+    MIIFgzCCA2ugAwIBAgIPXZONMGc2yAYdGsdUhGkHMA0GCSqGSIb3DQEBCwUAMDsx
+    CzAJBgNVBAYTAkVTMREwDwYDVQQKDAhGTk1ULVJDTTEZMBcGA1UECwwQQUMgUkFJ
+    ...
+    -----END CERTIFICATE-----
+```
+
+They can also be specified indirectly, putting the name of a PEM file in the
+`caFile` parameter:
+
+```yaml
+tls:
+  caFile: /etc/autoheal/my-ca.pem
 ```
 
 The `insecure` parameter controls whether to use an insecure connection to the

--- a/autoheal.yml
+++ b/autoheal.yml
@@ -42,6 +42,18 @@ awx:
     name: my-awx-credentials
 
   #
+  # Alternatively the user name and password can be also specified directly
+  # inside the configuration file. This is very convenient for development
+  # environments, but it is not recommended for production environments.
+  #
+  # credentials:
+  #   username: my-user
+  #   password: my-password
+  #
+  # Note that if both `credentialsRef` and `credentials` are used, then only
+  # `credentialsRef` will be used.
+
+  #
   # Reference to the Kubernetes secret that contains the trusted CA certificates
   # used to verify the TLS certificate presented by the AWX server. If not
   # present or empty then the global system trusted certificates will be used.
@@ -49,6 +61,23 @@ awx:
   tlsRef:
     namespace: my-namespace
     name: my-awx-tls
+
+  #
+  # Alternatively the trusted CA certificates can be also specified directly
+  # inside the configuration file.
+  #
+  # tls:
+  #   caCerts: |-
+  #     -----BEGIN CERTIFICATE-----
+  #     MIIFgzCCA2ugAwIBAgIPXZONMGc2yAYdGsdUhGkHMA0GCSqGSIb3DQEBCwUAMDsx
+  #     CzAJBgNVBAYTAkVTMREwDwYDVQQKDAhGTk1ULVJDTTEZMBcGA1UECwwQQUMgUkFJ
+  #     ...
+  #     -----END CERTIFICATE-----
+  #
+  # Or loaded from a file:
+  #
+  # tls:
+  #   caFile: /etc/pki/tls/certs/my-ca.pem
 
   #
   # Whether to use an insecure connection to the AWX server this should always
@@ -69,6 +98,7 @@ awx:
 
 #
 # This section describes how to throttle the execution of healing rules.
+#
 throttling:
   #
   # The time that the service will remember an executed healing action. If an
@@ -85,9 +115,10 @@ throttling:
   # Will have different values for the `template` field if the triggering alerts
   # have different `service` labels.
   #
-  # Interval is a duration string ,that is, a sequence of decimal numbers,
-  # each with optional fraction and a unit suffix, such as "300ms" or "2h45m".
-  # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". (For more details see https://golang.org/pkg/time/#Duration)
+  # Interval is a duration string ,that is, a sequence of decimal numbers, each
+  # with optional fraction and a unit suffix, such as "300ms" or "2h45m".  Valid
+  # time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". (For more details
+  # see https://golang.org/pkg/time/#Duration)
   #
   interval: 1h
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ limitations under the License.
 package config
 
 import (
+	"bytes"
 	"time"
 
 	autoheal "github.com/openshift/autoheal/pkg/apis/autoheal/v1alpha2"
@@ -48,7 +49,7 @@ type AWXConfig struct {
 	user                   string
 	password               string
 	insecure               bool
-	ca                     []byte
+	ca                     *bytes.Buffer
 	project                string
 	jobStatusCheckInterval time.Duration
 }
@@ -97,7 +98,10 @@ func (c *AWXConfig) Password() string {
 // the TLS certificate presented by the AWX server. If not provided the system cert pool will be used.
 //
 func (c *AWXConfig) CA() []byte {
-	return c.ca
+	if c.ca == nil {
+		return nil
+	}
+	return c.ca.Bytes()
 }
 
 // Project returns the name of the AWX project that contains the auto-heal job templates.

--- a/pkg/internal/data/config.go
+++ b/pkg/internal/data/config.go
@@ -48,9 +48,15 @@ type AWXConfig struct {
 	// Proxy is the address of the proxy server used to access the API of the AWX server.
 	Proxy string `json:"proxy,omitempty"`
 
+	// Credentials contains the user name and password.
+	Credentials *AWXCredentialsConfig `json:"credentials,omitempty"`
+
 	// CredentialsRef is the reference (name, and optionally namespace) of the secret that contains
 	// the user name and password used to access the AWX API.
 	CredentialsRef *core.SecretReference `json:"credentialsRef,omitempty"`
+
+	// TLS contains the TLS configuration.
+	TLS *TLSConfig `json:"tls,omitempty"`
 
 	// TLSRef is the reference (name, and optionally namespace) of the secret that contains the TLS
 	// certificates and keys used to access the AWX API.
@@ -64,6 +70,20 @@ type AWXConfig struct {
 
 	// JobStatusCheckInterval determines how often to check AWX active jobs status
 	JobStatusCheckInterval string `json:"jobStatusCheckInterval,omitempty"`
+}
+
+// AWXCredentialsConfig contains the credentials used to connect to the AWX server.
+//
+type AWXCredentialsConfig struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+// TLSConfig contains the TLS configuration.
+//
+type TLSConfig struct {
+	CACerts string `json:"caCerts,omitempty"`
+	CAFile  string `json:"caFile,omitempty"`
 }
 
 // ThrottlingConfig is used to mardhal and unmarshal the healing rule exeuction throttling


### PR DESCRIPTION
Currently the auto-heal server needs to read the AWX crendentials and CA
certificates from Kubernetes secret. This complicates things in
development environments, because the secrets have to be created before
using the server. To simplify things, this patch adds support for
reading the credentials and CA certificates directly from the
configuration file. For example:

```yaml
awx:
  address: https://my-awx.example.com/api
  credentials:
    username: autoheal
    password: ...
  tls:
    caFile: my-ca.pem
```

Using the `credentialsRef` and `tlsRef` sections to reference Kubernetes
is still supported and the recommended configuration when running the
server in production environments.