### PR TITLE
Start collection of AWX examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,16 @@ $ autoheal server --config-file=my.yml --logtostderr
 $ curl --data @examples/node-down-alert.json http://localhost:9099/alerts
 ```
 
-# Installing
+## Installing
 
 To install the service to an _OpenShift_ cluster use the template contained in
 the `template.yml` file. This template requires at the very minimum the address
 and the credentials to connect to the AWX or Ansible Tower server. See the
 `template.sh` script for an example of how to use it.
+
+## Dependencies
+
+In order to use the AWX API the auto-heal service uses a Go AWX client that is
+part of this repository, but that will be likely moved to a separate repository
+in the future. The code is in the [pkg/awx](pkg/awx) directory, and there is a
+collection of examples in the [examples/awx](examples/awx) directory.

--- a/examples/awx/README.md
+++ b/examples/awx/README.md
@@ -1,0 +1,25 @@
+# AWX Client Examples
+
+This directory contains a collections of examples that show how to use the AWX
+client.
+
+## Running the Examples
+
+In order to run the examples you will need to provide the details to connect to
+your AWX server, either modifiying the source code of the example or using the
+command line options. For example, to run the example that lists the job
+templates you can use the following command line:
+
+```bash
+$ go run list_job_templates.go \
+-url "https://awx.example.com/api" \
+-username "admin" \
+-password "..." \
+-ca-file "ca.pem" \
+-logtostderr \
+-v=2
+```
+
+Note that the `-logtostderr` and `-v=2` options aren't needed, but they are very
+convenient for development, as they ensure that all the HTTP traffic is dumped
+to the terminal.

--- a/examples/awx/list_job_templates.go
+++ b/examples/awx/list_job_templates.go
@@ -1,0 +1,90 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This example shows how to list the job templates.
+//
+// Use the following command to build and run it with all the debug output sent to the standard
+// error output:
+//
+//	go run list_job_templates.go \
+//		-url "https://awx.example.com/api" \
+//		-username "admin" \
+//		-password "..." \
+//		-ca-file "ca.pem" \
+//		-logtostderr \
+//		-v=2
+
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/openshift/autoheal/pkg/awx"
+)
+
+var (
+	url      string
+	username string
+	password string
+	proxy    string
+	insecure bool
+	caFile   string
+)
+
+func init() {
+	flag.StringVar(&url, "url", "https://awx.example.com/api", "API URL.")
+	flag.StringVar(&username, "username", "admin", "API user name.")
+	flag.StringVar(&password, "password", "", "API user password.")
+	flag.StringVar(&proxy, "proxy", "", "API proxy URL.")
+	flag.BoolVar(&insecure, "insecure", false, "Don't verify server certificate.")
+	flag.StringVar(&caFile, "ca-file", "", "Trusted CA certificates.")
+}
+
+func main() {
+	// Parse the command line:
+	flag.Parse()
+
+	// Connect to the server, and remember to close the connection:
+	connection, err := awx.NewConnectionBuilder().
+		Url(url).
+		Username(username).
+		Password(password).
+		Proxy(proxy).
+		CAFile(caFile).
+		Insecure(insecure).
+		Build()
+	if err != nil {
+		panic(err)
+	}
+	defer connection.Close()
+
+	// Find the resource that manages the collection of job templates:
+	templatesResource := connection.JobTemplates()
+
+	// Send the request to get the list of job templates:
+	getTemplatesRequest := templatesResource.Get()
+	getTemplatesResponse, err := getTemplatesRequest.Send()
+	if err != nil {
+		panic(err)
+	}
+
+	// Print the results:
+	templates := getTemplatesResponse.Results()
+	for _, template := range templates {
+		fmt.Printf("%d: %s\n", template.Id(), template.Name())
+	}
+}


### PR DESCRIPTION
This pull requests starts a collection of AWX examples. They will be initially
in the `examples/awx` directory.

In order to make examples simpler the pull request also adds a new `CAFile` method to the AWX connection builder, as that simplifies loading CA certificates.