### PR TITLE
Add autoheal_actions_requested_total counter

### DIFF
--- a/cmd/autoheal/alerts_worker.go
+++ b/cmd/autoheal/alerts_worker.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 
 	"github.com/golang/glog"
@@ -191,6 +192,13 @@ func (h *Healer) runRule(rule *autoheal.HealingRule, alert *alertmanager.Alert) 
 		)
 		return nil
 	}
+
+	// Increment the metric of requested heales.
+	h.actionRequested(
+		reflect.TypeOf(action).Elem().Name(),
+		rule.ObjectMeta.Name,
+		alert.Labels["alertname"],
+	)
 
 	// Process the templates inside the action:
 	template, err := NewObjectTemplateBuilder().

--- a/documentation/metrics.md
+++ b/documentation/metrics.md
@@ -21,8 +21,14 @@ All these metrics are prefixed with `autoheal_actions_`
 | Name             | Description                         | Type    |
 |------------------|-------------------------------------|---------|
 | initiated_total  | Number of initiated healing actions | Counter |
+| requested_total  | Number of requested healing actions | Counter |
 
 `initiated_total` indicates how many healing actions were successfully kicked off by the server. An AWX type action is counted when a SUCCESSFUL `launch` request was done against an AWX server.
+
+`requested_total` indicates how many healing actions were triggered by the server. An action that
+was rate limited by the server is counted here as well as a heal that failed to run for some reason.
+For example if autoheal failed to contact AWX for an AWX job, a heal will not start
+but it will be counted as requested.
 
 ## Prometheus supplied metrics
 


### PR DESCRIPTION
The new counter will include actions that were rate limited or otherwise failed to run.

Fixes the second item of https://github.com/openshift/autoheal/issues/53