### PR TITLE
Do not try to connect to openshift cluster on default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
 #   build-cross: Build the cross compiled release binaries.
 #   build-rpms: Build RPMs only for the Linux AMD64 target.
 #   build-images: Build images from the official RPMs.
+#   run-dev: Run autoheal server using dev defaults.
 
 OUT_DIR = _output
 OS_OUTPUT_GOPATH ?= 1
@@ -126,3 +127,12 @@ build-rpms:
 build-images: build-rpms
 	hack/build-images.sh
 .PHONY: build-images
+
+
+# Run autoheal server using dev defaults.
+#
+# Example:
+#   make run-dev
+run-dev: build
+	hack/run-dev.sh
+.PHONY: run-dev

--- a/README.md
+++ b/README.md
@@ -316,3 +316,25 @@ In order to use the AWX API the auto-heal service uses a Go AWX client that is
 part of this repository, but that will be likely moved to a separate repository
 in the future. The code is in the [pkg/awx](pkg/awx) directory, and there is a
 collection of examples in the [examples/awx](examples/awx) directory.
+
+## Development
+
+If needed development can be done without an OpenShift cluster, simulating
+OpenShift's alert manager using curl commands.
+
+In the examples dir we have examples of firing alerts and a configuration file
+that does not require a connection to a working OpenShift cluster.
+
+To run autoheal in dev mode (without a running OpenShift cluster) developers can
+use the dev config file in the examples dir.
+
+To simulate alerts firing, developers can use the example alerts.
+
+```
+$ make build
+$ make run-dev
+```
+
+```
+$ curl --data @examples/node-down-alert.json http://localhost:9099/alerts
+```

--- a/examples/autoheal-dev.yml
+++ b/examples/autoheal-dev.yml
@@ -1,0 +1,61 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+awx:
+  address: http://127.0.0.1:8080/api
+
+  credentials:
+    username: my-user
+    password: my-password
+
+  project: "My project"
+
+throttling:
+  interval: 5s
+
+rules:
+- metadata:
+    name: start-node
+  labels:
+    alertname: "NodeDown"
+  awxJob:
+    template: "Start node"
+    extraVars: |-
+      {
+        "node": "{{ $labels.instance }}"
+      }
+
+- metadata:
+    name: say-hello
+  labels:
+    alertname: "NewFriend"
+  batchJob:
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      namespace: default
+      name: hello
+    spec:
+      template:
+        spec:
+          containers:
+          - name: python
+            image: python
+            command:
+            - python
+            - -c
+            - print("Hello {{ $labels.name }}!")
+          restartPolicy: Never

--- a/hack/run-dev.sh
+++ b/hack/run-dev.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script sets up a go workspace locally and run the autoheal server.
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+
+# Get host plataform
+platform="$(os::build::host_platform)"
+
+# Get platform binary and extention
+binary="${OS_OUTPUT_BINPATH}/${platform}/autoheal"
+if [[ $platform == "windows/amd64" ]]; then
+	binary=("${binary}.exe")
+else
+	binary=("${binary}")
+fi
+
+# Run autoheal server using dev defaults
+"${binary}" server --config-file=examples/autoheal-dev.yml --logtostderr


### PR DESCRIPTION
**Description**

Current "autoheal.yml" example file, try to connect to openshift cluster by default.

In a development enviorment this can be avoided on development system by not sending the optional "credentialsRef" and "tlsRef" vars.

The PR ads an example dev config file that does not require an openshift cluster to run, and add a makefile target to check that the autoheal server can start without need to connect to an openshift cluster.