### PR TITLE
Add a mock awx server for dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,6 @@ build-images: build-rpms
 #
 # Example:
 #   make run-dev
-run-dev: build
+run-dev:
 	hack/run-dev.sh
 .PHONY: run-dev

--- a/README.md
+++ b/README.md
@@ -319,14 +319,14 @@ collection of examples in the [examples/awx](examples/awx) directory.
 
 ## Development
 
-If needed development can be done without an OpenShift cluster, simulating
-OpenShift's alert manager using curl commands.
+If needed for development, we can run the server without an OpenShift cluster,
+simulating OpenShift's alert manager using curl commands.
 
-In the examples dir we have examples of firing alerts and a configuration file
+In the examples dir we have examples of firing alerts, and a configuration file
 that does not require a connection to a working OpenShift cluster.
 
-To run autoheal in dev mode (without a running OpenShift cluster) developers can
-use the dev config file in the examples dir.
+To run autoheal in dev mode (without a running OpenShift cluster) developers
+can use the dev config file in the examples dir.
 
 To simulate alerts firing, developers can use the example alerts.
 
@@ -337,4 +337,13 @@ $ make run-dev
 
 ```
 $ curl --data @examples/node-down-alert.json http://localhost:9099/alerts
+```
+
+When developing features that does not require AWX server, developers can use
+a mock-awx server from the examples dir. The mock server will listen on port
+8080.
+
+```
+$ cd examples/mock-awx
+$ go run mock-awx.go
 ```

--- a/examples/mock-awx/mock-awx.go
+++ b/examples/mock-awx/mock-awx.go
@@ -1,0 +1,83 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package main contains a mock AWX server for autoheal development
+//
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+func logRequest(r *http.Request) {
+	log.Printf("%s: %s", r.Method, r.URL.Path)
+
+	if r.Method == "POST" {
+		// Read body
+		body, err := ioutil.ReadAll(r.Body)
+		defer r.Body.Close()
+		if err == nil {
+			log.Print("Request body:")
+			log.Print(string(body))
+		}
+	}
+}
+
+func handlerPostLaunch(w http.ResponseWriter, r *http.Request) {
+	POST_JOB := `{
+      "job": 4
+    }`
+
+	log.Print("Request: launch a job template.")
+
+	logRequest(r)
+	w.Write([]byte(POST_JOB))
+}
+
+func handlerGetJobList(w http.ResponseWriter, r *http.Request) {
+	GET_TEMPLATES := `{
+      "count": 1,
+      "next": null,
+      "previous": null,
+      "results": [{"id": 1}]
+    }`
+
+	log.Print("Request: list job templates.")
+
+	logRequest(r)
+	w.Write([]byte(GET_TEMPLATES))
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	EMPTY_JSON := `{}`
+
+	log.Print("Request: un handled request.")
+
+	logRequest(r)
+	w.Write([]byte(EMPTY_JSON))
+}
+
+func main() {
+	http.HandleFunc("/api/v2/job_templates/1/launch/", handlerPostLaunch)
+	http.HandleFunc("/api/v2/job_templates/", handlerGetJobList)
+	http.HandleFunc("/", handler)
+
+	log.Print("Running mock AWX server on port 8080.")
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
**Description**

This PR adds a mock AWX server, when developing features that does not require AWX server, developers can use a mock-awx server from the examples dir. The mock server will listen on port
8080.

**Running**
$ cd examples/mock-awx
$ go run mock-awx.go

