### PR TITLE
Proposal: Extract ActionRunner interface

### DIFF
--- a/cmd/autoheal/action_runner.go
+++ b/cmd/autoheal/action_runner.go
@@ -1,0 +1,33 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	alertmanager "github.com/openshift/autoheal/pkg/alertmanager"
+	autoheal "github.com/openshift/autoheal/pkg/apis/autoheal"
+)
+
+type ActionRunnerType int
+
+const (
+	ActionRunnerTypeAWX ActionRunnerType = iota
+	ActionRunnerTypeBatch
+)
+
+type ActionRunner interface {
+	RunAction(rule *autoheal.HealingRule, action interface{}, alert *alertmanager.Alert) error
+}

--- a/cmd/autoheal/server.go
+++ b/cmd/autoheal/server.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 
+	"github.com/openshift/autoheal/pkg/metrics"
 	"github.com/openshift/autoheal/pkg/signals"
 )
 
@@ -121,7 +122,7 @@ func serverRun(cmd *cobra.Command, args []string) {
 	}
 
 	// Register exported metrics:
-	healer.initExportedMetrics()
+	metrics.InitExportedMetrics()
 
 	// Run the healer:
 	if err = healer.Run(stopCh); err != nil {

--- a/pkg/awxrunner/active_jobs_worker.go
+++ b/pkg/awxrunner/active_jobs_worker.go
@@ -14,31 +14,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package awxrunner
 
 import (
 	"github.com/golang/glog"
-	"k8s.io/apimachinery/pkg/util/runtime"
-
 	"github.com/openshift/autoheal/pkg/apis/autoheal"
+	"github.com/openshift/autoheal/pkg/metrics"
+	"k8s.io/apimachinery/pkg/util/runtime"
 )
 
-func (h *Healer) runActiveJobsWorker() {
+func (r *Runner) runActiveJobsWorker() {
 	glog.Infof("Going over active jobs queue.")
 
 	finishedJobs := make([]int, 0)
 
-	h.activeJobs.Range(func(key interface{}, value interface{}) bool {
+	r.activeJobs.Range(func(key interface{}, value interface{}) bool {
 		id := key.(int)
 		rule := value.(*autoheal.HealingRule)
-		finished, err := h.checkAWXJobStatus(id)
+		finished, err := r.checkAWXJobStatus(id)
 		if err != nil {
 			runtime.HandleError(err)
 		}
 
 		if finished {
 			finishedJobs = append(finishedJobs, id)
-			h.actionCompleted(
+			metrics.ActionCompleted(
 				"AWXJob",
 				rule.AWXJob.Template,
 				rule.ObjectMeta.Name,
@@ -53,6 +53,6 @@ func (h *Healer) runActiveJobsWorker() {
 			"Removing finished job `%v` from queue ",
 			job,
 		)
-		h.activeJobs.Delete(job)
+		r.activeJobs.Delete(job)
 	}
 }

--- a/pkg/metrics/metrics_exporter.go
+++ b/pkg/metrics/metrics_exporter.go
@@ -1,4 +1,4 @@
-package main
+package metrics
 
 import (
 	"net/http"
@@ -24,15 +24,19 @@ var (
 	)
 )
 
-func (h *Healer) metricsHandler() http.Handler {
+// Handle /metrics requsts, retrun a list of all exported metrics
+//
+func Handler() http.Handler {
 	return promhttp.Handler()
 }
 
-func (h *Healer) initExportedMetrics() {
+// Init autoheal prometheus exported metrics
+//
+func InitExportedMetrics() {
 	prometheus.MustRegister(actionsRequested, actionsLaunched)
 }
 
-func (h *Healer) actionStarted(
+func ActionStarted(
 	actionType,
 	templateName,
 	ruleName string,
@@ -47,7 +51,7 @@ func (h *Healer) actionStarted(
 	).Inc()
 }
 
-func (h *Healer) actionCompleted(
+func ActionCompleted(
 	actionType,
 	templateName,
 	ruleName string,
@@ -70,7 +74,7 @@ func (h *Healer) actionCompleted(
 	).Inc()
 }
 
-func (h *Healer) actionRequested(actionType, rule, alert string) {
+func ActionRequested(actionType, rule, alert string) {
 	actionsRequested.With(
 		map[string]string{
 			"type":  actionType,


### PR DESCRIPTION
## What this does?

- Extracting run*Job to a ~~JobRunner~~ ActionRunner interface and adds structs to implement this interface.
- Adds a ~~JobRunner~~ ActionRunner map to healer.

## Why do this?

1. This extracts away methods and fields from healer - an already very heavy struct and creates ~~JobRunners~~ ActionRunner specific method and implementations which healer shouldn't be aware of.
2. This also, allows to extend ~~JobRunners~~ ActionRunner to any number and variety (If someday we would like to add more options more targets for jobs)
3. And most importantly; it allows me to stub for `RunJob` and by that write tests for `alerts_worker` and other parts of healer which currently not testable :cry: .

cc: @yaacov @moolitayer @jhernand  