### PR TITLE
Expose metrics on job status

### DIFF
--- a/cmd/autoheal/awx_job.go
+++ b/cmd/autoheal/awx_job.go
@@ -111,10 +111,14 @@ func (h *Healer) launchAWXJob(
 		templateName,
 		response.Job,
 	)
-	h.incrementAwxActions(action, rule.ObjectMeta.Name)
+	h.actionStarted(
+		"AWXJob",
+		templateName,
+		rule.ObjectMeta.Name,
+	)
 
 	// Add the job to active jobs map for tracking
-	h.activeJobs.Store(response.Job, response.Job)
+	h.activeJobs.Store(response.Job, rule)
 
 	return nil
 }
@@ -158,7 +162,6 @@ func (h *Healer) checkAWXJobStatus(jobID int) (finished bool, err error) {
 	)
 
 	finished = job.IsFinished()
-	// TODO: save status as metric
 
 	return
 }

--- a/documentation/metrics.md
+++ b/documentation/metrics.md
@@ -20,15 +20,15 @@ All these metrics are prefixed with `autoheal_actions_`
 
 | Name             | Description                         | Type    |
 |------------------|-------------------------------------|---------|
-| initiated_total  | Number of initiated healing actions | Counter |
+| launched         | Number of started healing actions   | Gauge   |
 | requested_total  | Number of requested healing actions | Counter |
-
-`initiated_total` indicates how many healing actions were successfully kicked off by the server. An AWX type action is counted when a SUCCESSFUL `launch` request was done against an AWX server.
 
 `requested_total` indicates how many healing actions were triggered by the server. An action that
 was rate limited by the server is counted here as well as a heal that failed to run for some reason.
 For example if autoheal failed to contact AWX for an AWX job, a heal will not start
 but it will be counted as requested.
+
+`launched` indicates how many healing actions started, partitioned by status `running`|`completed`.
 
 ## Prometheus supplied metrics
 


### PR DESCRIPTION
autoheal_actions_initiated_total is renamed to autoheal_actions_launched
and is now a gauge instead of a counter. this gauge is used from the 
moment we launch a job and until it is finished(including).

Fix the first item of #53 