### PR TITLE
hack/test-go: Remove -i flag to allow running tests without root

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -135,7 +135,7 @@ if [[ -n "${junit_report}" ]]; then
     # we don't care if the `go test` fails in this pipe, as we want to generate the report and summarize the output anyway
     set +o pipefail
 
-    go test -i ${gotest_flags} ${test_packages}
+    go test ${gotest_flags} ${test_packages}
     go test ${gotest_flags} ${test_packages} 2>"${test_error_file}" | tee "${JUNIT_REPORT_OUTPUT}"
 
     test_return_code="${PIPESTATUS[0]}"
@@ -162,7 +162,7 @@ $( cat "${test_error_file}") "
 
 elif [[ -n "${coverage_output_dir}" ]]; then
     # we need to generate coverage reports
-    go test -i ${gotest_flags} ${test_packages}
+    go test ${gotest_flags} ${test_packages}
     for test_package in ${test_packages}; do
         mkdir -p "${coverage_output_dir}/${test_package}"
         local_gotest_flags="${gotest_flags} -coverprofile=${coverage_output_dir}/${test_package}/profile.out"
@@ -187,6 +187,6 @@ elif [[ -n "${dlv_debug}" ]]; then
     dlv test ${test_packages}
 else
     # we need to generate neither jUnit XML nor coverage reports
-    go test -i ${gotest_flags} ${test_packages}
+    go test ${gotest_flags} ${test_packages}
     go test ${gotest_flags} ${test_packages}
 fi


### PR DESCRIPTION
This PR allows running `make check` without using root and without having the go compiler recompile and test the standard library installed in system paths.

/cc @jhernand 