### PR TITLE
hack: Don't hardcode go version in verify_go_version

### DIFF
--- a/hack/lib/util/golang.sh
+++ b/hack/lib/util/golang.sh
@@ -8,7 +8,7 @@ function os::golang::verify_go_version() {
 
 	local go_version
 	go_version=($(go version))
-	if [[ "${go_version[2]}" != go1.8* ]]; then
+	if [[ "${go_version[2]}" != "${OS_REQUIRED_GO_VERSION}"* ]]; then
 		os::log::info "Detected go version: ${go_version[*]}."
 		if [[ -z "${PERMISSIVE_GO:-}" ]]; then
 			os::log::fatal "Please install Go version ${OS_REQUIRED_GO_VERSION} or use PERMISSIVE_GO=y to bypass this check."


### PR DESCRIPTION
Our OS_REQUIRED_GO_VERSION is go1.9, so we shouldn't hardcode go1.8

This function is called when you try running `make check`.

Upstream PR: https://github.com/openshift/release/pull/814

/cc @jhernand 