### PR TITLE
Sync template with `openshift-ansible`

### DIFF
--- a/template.sh
+++ b/template.sh
@@ -20,15 +20,10 @@
 # minimal configuration.
 
 oc process \
---filename=template.yml \
---param=OAUTH_PROXY_SECRET="$(dd if=/dev/urandom count=1 bs=32 2>/dev/null | base64 --wrap=0)" \
---param=AWX_ADDRESS="https://my-awx.example.com/api" \
---param=AWX_USER="$(echo -n 'autoheal' | base64 --wrap=0)" \
---param=AWX_PASSWORD="$(echo -n 'redhat123' | base64 --wrap=0)" \
+  --filename="template.yml" \
+  --param=IMAGE="openshift/origin-autoheal:latest" \
+  --param=CONFIG="$(base64 examples/autoheal-dev.yml)" \
+  --param=SECRET="$(openssl rand -base64 32)" \
 | \
-oc apply --filename=-
-
-# Add a line like this if you have a `ca.crt` file containing the CA
-# certificates needed to connect to the AWX server:
-#
-# --param=AWX_CA="$(base64 --wrap=0 ca.crt)" \
+oc apply \
+  --filename=-

--- a/template.yml
+++ b/template.yml
@@ -18,6 +18,8 @@
 # for a working instance of the auto-heal service. See the `template.sh` file
 # for an example of how to use it.
 
+---
+
 apiVersion: v1
 kind: Template
 metadata:
@@ -27,244 +29,189 @@ metadata:
     tags: "autoheal"
 
 parameters:
-- name: NAME
-  description: |-
-    The name of the auto-heal service. Will also be used as a prefix for the
-    names of secrets and other objects.
-  value: autoheal
-- name: NAMESPACE
-  description: |-
-    The namespace where the auto-heal service will be created.
-  value: openshift-autoheal
-- name: OAUTH_PROXY_SECRET
-  description: |-
-    Secret used to encrypt OAuth session cookies.
-  value: openshift-monitoring
-- name: AWX_ADDRESS
-  description: |-
-    The URL of the AWX API endpoint, including the `/api` suffix, but not the
-    `/v1` or `/v2` suffixes. For example `https://my-awx.example.com/api`.
-- name: AWX_PROXY
-  description: |-
-    The URL of the proxy server used to connect to the AWX API. If not present
-    or empty then no proxy server will be used. For example
-    `http://my-proxy.example.com:3128`.
-- name: AWX_USER
-  description: |-
-    The name of the user that will be used to connect to the AWX API. The value
-    must be encoded using Base64.
-- name: AWX_PASSWORD
-  description: |-
-    The password of the user that will be used to connect to the AWX API. The
-    value must be encoded using Base64.
-- name: AWX_CA
-  description: |-
-    The trusted CA certificates used to verify the TLS certificate presented by
-    the AWX server. If not present or empty then the global system trusted
-    certificates will be used. The value must be encoded using Base64.
-- name: AWX_PROJECT
-  description: |-
-    The name of the AWX project that contains the job templates that the
-    auto-heal service will use to respond to alerts.
-  value: "Auto-heal"
+- name: IMAGE
+  description: The name of the image.
+- name: CONFIG
+  description: The BASE64 encoded content of the configuration file.
+- name: SECRET
+  description: The BASE64 encoded secret used to encrypt OAuth session cookies.
 
 objects:
 
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
-    namespace: ${NAMESPACE}
-    name: ${NAME}
+    name: autoheal
+    labels:
+      app: autoheal
 
-- apiVersion: v1
+- apiVersion: authorization.openshift.io/v1
   kind: Role
   metadata:
-    namespace: ${NAMESPACE}
-    name: ${NAME}
+    name: autoheal
+    labels:
+      app: autoheal
   rules:
   - apiGroups:
     - ""
     resources:
     - secrets
     resourceNames:
-    - ${NAME}-awx-credentials
-    - ${NAME}-awx-tls
+    - autoheal-config
     verbs:
     - get
 
-- apiVersion: v1
-  kind: RoleBinding
-  metadata:
-    namespace: ${NAMESPACE}
-    name: ${NAME}
-  roleRef:
-    namespace: ${NAMESPACE}
-    name: ${NAME}
-  subjects:
-  - kind: ServiceAccount
-    name: ${NAME}
-  userNames:
-  - system:serviceaccount:${NAMESPACE}:${NAME}
-
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    namespace: ${NAMESPACE}
-    name: ${NAME}-awx-credentials
-  data:
-    username: ${AWX_USER}
-    password: ${AWX_PASSWORD}
-
-- apiVersion: rbac.authorization.k8s.io/v1beta1
-  kind: ClusterRoleBinding
-  metadata:
-    name: ${NAME}-auth-delegator
-  roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: ClusterRole
-    name: system:auth-delegator
-  subjects:
-  - kind: ServiceAccount
-    name: ${NAME}
-    namespace: ${NAMESPACE}
-
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    namespace: ${NAMESPACE}
-    name: ${NAME}-awx-tls
-  data:
-    ca.crt: ${AWX_CA}
-
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    namespace: ${NAMESPACE}
-    name: ${NAME}-proxy-cookie
-  data:
-    session_secret: ${OAUTH_PROXY_SECRET}
-
-- apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: authorization.openshift.io/v1
   kind: ClusterRole
   metadata:
-    name: ${NAME}-access
+    name: autoheal-access
+    labels:
+      app: autoheal
   rules:
   - apiGroups:
     - ""
     resources:
     - secrets
     resourceNames:
-    - ${NAME}-access-key
+    - autoheal-access-key
     verbs:
     - get
 
-- apiVersion: rbac.authorization.k8s.io/v1
+- apiVersion: authorization.openshift.io/v1
   kind: RoleBinding
   metadata:
-    namespace: ${NAMESPACE}
-    name: alertmanager-${NAME}-access
+    name: autoheal
+    labels:
+      app: autoheal
   roleRef:
-    apiGroup: rbac.authorization.k8s.io
+    namespace: openshift-autoheal
+    name: autoheal
+  subjects:
+  - kind: ServiceAccount
+    namespace: openshift-autoheal
+    name: autoheal
+
+- apiVersion: authorization.openshift.io/v1
+  kind: RoleBinding
+  metadata:
+    name: alertmanager-autoheal-access
+    labels:
+      app: autoheal
+  roleRef:
     kind: ClusterRole
-    name: ${NAME}-access
+    name: autoheal-access
   subjects:
   - kind: ServiceAccount
     namespace: openshift-monitoring
     name: alertmanager-main
 
-- apiVersion: v1
-  kind: ConfigMap
+- apiVersion: authorization.openshift.io/v1
+  kind: ClusterRoleBinding
   metadata:
-    namespace: ${NAMESPACE}
-    name: ${NAME}-config
+    name: autoheal-auth-delegator
+    labels:
+      app: autoheal
+  roleRef:
+    kind: ClusterRole
+    name: system:auth-delegator
+  subjects:
+  - kind: ServiceAccount
+    namespace: openshift-autoheal
+    name: autoheal
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: autoheal-config
+    labels:
+      app: autoheal
   data:
-    autoheal.yml: |-
-      awx:
-        address: ${AWX_ADDRESS}
-        proxy: ${AWX_PROXY}
-        credentialsRef:
-          namespace: ${NAMESPACE}
-          name: ${NAME}-awx-credentials
-        tlsRef:
-          namespace: ${NAMESPACE}
-          name: ${NAME}-awx-tls
-        project: ${AWX_PROJECT}
+    autoheal.yml: ${CONFIG}
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: autoheal-proxy-cookie
+  data:
+    session_secret: ${SECRET}
 
 - apiVersion: apps/v1beta1
   kind: Deployment
   metadata:
-    namespace: ${NAMESPACE}
-    name: ${NAME}
+    name: autoheal
+    labels:
+      app: autoheal
   spec:
     selector:
       matchLabels:
-        app: ${NAME}
+        app: autoheal
     replicas: 1
     template:
       metadata:
         labels:
-          app: ${NAME}
+          app: autoheal
       spec:
-        serviceAccountName: ${NAME}
+        serviceAccountName: autoheal
         volumes:
         - name: config
-          configMap:
-            name: ${NAME}-config
-        - name: ${NAME}-proxy-tls
           secret:
-            secretName: ${NAME}-proxy-tls
-        - name: ${NAME}-proxy-cookie
+            secretName: autoheal-config
+        - name: proxy-tls
           secret:
-            secretName: ${NAME}-proxy-cookie
+            secretName: autoheal-proxy-tls
+        - name: proxy-cookie
+          secret:
+            secretName: autoheal-proxy-cookie
         containers:
-        - name: oauth-proxy
+        - name: proxy
           image: openshift/oauth-proxy:v1.1.0
           imagePullPolicy: IfNotPresent
+          volumeMounts:
+          - mountPath: /etc/tls/private
+            name: proxy-tls
+          - mountPath: /etc/proxy/secrets
+            name: proxy-cookie
           ports:
           - containerPort: 8443
             name: public
           args:
           - --https-address=:8443
           - --provider=openshift
-          - --openshift-service-account=${NAME}
+          - --openshift-service-account=autoheal
           - --upstream=http://localhost:9099
           - --tls-cert=/etc/tls/private/tls.crt
           - -email-domain=*
-          - '-openshift-sar={"resource": "secrets", "verb": "get", "name": "${NAME}-access-key", "namespace": "${NAMESPACE}"}'
-          - '-openshift-delegate-urls={"/": {"resource": "secrets", "verb": "get", "name": "${NAME}-access-key", "namespace": "${NAMESPACE}"}}'
+          - '-openshift-sar={ "resource": "secrets", "verb": "get", "name": "autoheal-access-key", "namespace": "openshift-autoheal" }'
+          - '-openshift-delegate-urls={ "/": { "resource": "secrets", "verb": "get", "name": "autoheal-access-key", "namespace": "openshift-autoheal" } }'
           - -tls-key=/etc/tls/private/tls.key
           - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
           - -cookie-secret-file=/etc/proxy/secrets/session_secret
           - -openshift-ca=/etc/pki/tls/cert.pem
           - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-          volumeMounts:
-          - mountPath: /etc/tls/private
-            name: ${NAME}-proxy-tls
-          - mountPath: /etc/proxy/secrets
-            name: ${NAME}-proxy-cookie
-        - name: service
-          image: openshift/origin-autoheal:latest
+        - name: receiver
+          image: ${IMAGE}
           imagePullPolicy: IfNotPresent
           volumeMounts:
           - name: config
-            mountPath: /etc/autoheal
+            mountPath: /etc/autoheal/config.d
           command:
           - /usr/bin/autoheal
           args:
           - server
-          - --config-file=/etc/autoheal/autoheal.yml
+          - --config-file=/etc/autoheal/config.d
           - --logtostderr
 
 - apiVersion: v1
   kind: Service
   metadata:
-    namespace: ${NAMESPACE}
-    name: ${NAME}
+    name: receiver
+    labels:
+      app: autoheal
     annotations:
-      service.alpha.openshift.io/serving-cert-secret-name: ${NAME}-proxy-tls
+      service.alpha.openshift.io/serving-cert-secret-name: autoheal-proxy-tls
   spec:
     selector:
-      app: ${NAME}
+      app: autoheal
     ports:
     - name: autoheal
       port: 443


### PR DESCRIPTION
This patch updates the _OpenShift_ template to make it identical to theone that will be used by the install role that is proposed here:

  Add auto-heal role and playbooks
  https://github.com/openshift/openshift-ansible/pull/7753