### PR TITLE
Cover more config reading errors

### DIFF
--- a/cmd/autoheal/server.go
+++ b/cmd/autoheal/server.go
@@ -80,28 +80,30 @@ func serverRun(cmd *cobra.Command, args []string) {
 
 	// Load the Kubernetes configuration:
 	var config *rest.Config
-	_, err = os.Stat(serverKubeConfig)
-	if os.IsNotExist(err) {
-		glog.Infof(
-			"The Kubernetes configuration file '%s' doesn't exist, will try to use the "+
-				"in-cluster configuration",
-			serverKubeConfig,
-		)
-		config, err = rest.InClusterConfig()
-		if err != nil {
-			glog.Fatalf(
-				"Error loading in-cluster REST client configuration: %s",
-				err.Error(),
-			)
-		}
+	config, err = rest.InClusterConfig()
+	if err == nil {
+		glog.Infof("Using in-cluster configuration")
 	} else {
-		config, err = clientcmd.BuildConfigFromFlags(serverKubeAddress, serverKubeConfig)
-		if err != nil {
+		glog.Infof(
+			"Error loading in-cluster REST client configuration: %s. Trying kube config...",
+			err.Error(),
+		)
+		_, err = os.Stat(serverKubeConfig)
+		if os.IsNotExist(err) || os.IsPermission(err) || os.IsTimeout(err) {
 			glog.Fatalf(
-				"Error loading REST client configuration from file '%s': %s",
+				"The Kubernetes configuration file %s can not be read: ",
 				serverKubeConfig,
 				err.Error(),
 			)
+		} else {
+			config, err = clientcmd.BuildConfigFromFlags(serverKubeAddress, serverKubeConfig)
+			if err != nil {
+				glog.Fatalf(
+					"Error loading REST client configuration from file '%s': %s. No viable configuration found.",
+					serverKubeConfig,
+					err.Error(),
+				)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/openshift/autoheal/issues/14
Cover more config reading errors such as persmission denied on `.kube/config`.

```Bash
$ chmod 000 ~/.kube/config
$ ./_output/local/bin/linux/amd64/autoheal server --config-file=./examples/autoheal-dev.yml --logtostderr
I0429 15:56:39.455527   29602 server.go:96] The Kubernetes configuration file '.../.kube/config' can not be read: 'open .../.kube/config: permission denied', will try to use the in-cluster configuration
```


@jhernand @zgalor @elad661 Please review