### PR TITLE
Add members of the team to the `OWNERS` file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,13 @@
 reviewers:
+- cben
+- elad661
 - jhernand
 - moolitayer
+- nimrodshn
+- oourfali
+- yaacov
+- zeari
+- zgalor
 
 approvers:
 - jhernand


### PR DESCRIPTION
This pull requests adds the members of the team to the `OWNERS` file as reviewers.