### PR TITLE
object_template: Add tests

### DIFF
--- a/cmd/autoheal/object_template_test.go
+++ b/cmd/autoheal/object_template_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+)
+
+type TemplateTestDataNested struct {
+	StructKey string
+}
+
+type TemplateTestData struct {
+	Map    map[string]string
+	Str    string
+	Struct TemplateTestDataNested
+}
+
+func TestProcess(t *testing.T) {
+	template, err := NewObjectTemplateBuilder().
+		Delimiters("[", "]").
+		Variable("map", ".Map").
+		Variable("str", ".Str").
+		Variable("struct", ".Struct").
+		Build()
+
+	if err != nil {
+		t.Errorf("Error building ObjectTemplate: %v", err)
+	}
+
+	params := TemplateTestData{
+		Map:    map[string]string{"mapkey": "mapvalue"},
+		Str:    "This is a string",
+		Struct: TemplateTestDataNested{StructKey: "foo"},
+	}
+
+	input := map[string]string{
+		"a": "Test [ $foo ] test [ $bar ]",
+		"b": "Map=[ $map ], str=[ $str ], struct=[ $struct ]",
+	}
+	err = template.Process(&input, params)
+	if err != nil {
+		t.Errorf("Error processing template: %v", err)
+	}
+
+	if input["a"] != "Test [ $foo ] test [ $bar ]" {
+		t.Errorf("Input changed even though it didn't match template! %v", input["a"])
+	}
+
+	expected := "Map=map[mapkey:mapvalue], str=This is a string, struct={foo}"
+	if input["b"] != expected {
+		t.Errorf("Unexpected template result - expected '%v', got '%v'", expected, input["b"])
+	}
+
+}


### PR DESCRIPTION
Slowly but steadily increasing our test coverage while learning Go in the process.

This PR adds tests to object_template. Note that as object_template will support more types, more tests for these should be added.

cc: @jhernand @nimrodshn @zgalor @moolitayer Please review. All feedback is highly appreciated (even tiny nitpicks).

for reference: issue #44 