### PR TITLE
Fix bug of templating a string field

### DIFF
--- a/cmd/autoheal/object_template.go
+++ b/cmd/autoheal/object_template.go
@@ -139,6 +139,11 @@ func (t *ObjectTemplate) processValue(input reflect.Value, data interface{}) (ou
 			text, err := t.processString(output, data)
 			if err == nil {
 				output = reflect.ValueOf(text)
+
+				// update settable values in place
+				if input.CanSet() {
+					input.SetString(text)
+				}
 			}
 		case reflect.Array:
 			// Not implemented yet.
@@ -152,7 +157,7 @@ func (t *ObjectTemplate) processValue(input reflect.Value, data interface{}) (ou
 					return
 				}
 
-				// update the processed vaule in the map
+				// update the processed value in the map
 				output.SetMapIndex(k, v)
 			}
 		case reflect.Struct:

--- a/cmd/autoheal/object_template_test.go
+++ b/cmd/autoheal/object_template_test.go
@@ -48,11 +48,74 @@ func TestProcess(t *testing.T) {
 		Struct: TemplateTestDataNested{StructKey: "foo"},
 	}
 
+	testProcessStringInput(t, template, params)
+	testProcessStructInput(t, template, params)
+	testProcessMapInput(t, template, params)
+
+}
+
+// check basic string templating:
+func testProcessStringInput(t *testing.T, template *ObjectTemplate, params TemplateTestData) {
+	input := "Test [ $foo ] test [ $bar ]"
+	err := template.Process(&input, params)
+	if err != nil {
+		t.Errorf("Error processing template: %v", err)
+	}
+
+	if input != "Test [ $foo ] test [ $bar ]" {
+		t.Errorf("Input changed even though it didn't match template! %v", input)
+	}
+
+	input = "str=[ $str ]"
+	err = template.Process(&input, params)
+	if err != nil {
+		t.Errorf("Error processing template: %v", err)
+	}
+
+	expected := "str=This is a string"
+
+	if input != expected {
+		t.Errorf("Unexpected template result - expected '%v', got '%v'", expected, input)
+	}
+}
+
+// check struct templating:
+func testProcessStructInput(t *testing.T, template *ObjectTemplate, params TemplateTestData) {
+	type TestStruct struct {
+		Templated  string
+		Unchanged  string
+		unsettable string //Unexported fields are unsettable via reflection
+	}
+	input := TestStruct{
+		Templated:  "str=[ $str ]",
+		Unchanged:  "Test [ $foo ] test [ $bar ]",
+		unsettable: "str=[ $str ]",
+	}
+
+	err := template.Process(&input, params)
+	if err != nil {
+		t.Errorf("Error processing template: %v", err)
+	}
+
+	expected := TestStruct{
+		Templated:  "str=This is a string",
+		Unchanged:  "Test [ $foo ] test [ $bar ]",
+		unsettable: "str=[ $str ]",
+	}
+
+	if input != expected {
+		t.Errorf("Unexpected template result - expected '%v', got '%v'", expected, input)
+	}
+
+}
+
+// check map templating:
+func testProcessMapInput(t *testing.T, template *ObjectTemplate, params TemplateTestData) {
 	input := map[string]string{
 		"a": "Test [ $foo ] test [ $bar ]",
 		"b": "Map=[ $map ], str=[ $str ], struct=[ $struct ]",
 	}
-	err = template.Process(&input, params)
+	err := template.Process(&input, params)
 	if err != nil {
 		t.Errorf("Error processing template: %v", err)
 	}
@@ -65,5 +128,4 @@ func TestProcess(t *testing.T) {
 	if input["b"] != expected {
 		t.Errorf("Unexpected template result - expected '%v', got '%v'", expected, input["b"])
 	}
-
 }


### PR DESCRIPTION
This was presented in the refactoring done in e7b7f1ce24be397c12762b72404dbdabbcf0aa36
String values have to be set explicitly using `SetString()`
`SetString` is called only for settable values.
See laws of reflection here:
https://blog.golang.org/laws-of-reflection
    
Also added tests for `Process()` with the inputs struct and basic string
