### PR TITLE
Buffer file change events

### DIFF
--- a/pkg/config/event_listener.go
+++ b/pkg/config/event_listener.go
@@ -19,6 +19,8 @@ limitations under the License.
 package config
 
 import (
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/yaacov/observer/observer"
 )
@@ -64,6 +66,9 @@ func (e *eventListener) open() {
 	if e.configFilesChangedObserver == nil {
 		e.configFilesChangedObserver = new(observer.Observer)
 		e.configFilesChangedObserver.Open()
+
+		// Buffer file change events, 1e6 ns == 1 ms
+		e.configFilesChangedObserver.SetBufferDuration(1 * time.Millisecond)
 	}
 
 	// Start a change watcher over loaded config files.


### PR DESCRIPTION
**Description**

Last step in solving #41

When editing config files using some editors and automatic tools we may get several file change events in a small time frame. This PR buffer events that happen during 1 sec into one event.

**Screenshoots**

Before:
![before-1](https://user-images.githubusercontent.com/2181522/39696444-6cd3f83a-51f6-11e8-8648-15cf7b34ed4e.gif)

After:
![after-1](https://user-images.githubusercontent.com/2181522/39696256-dcc8680c-51f5-11e8-9ebf-848d4225121a.gif)