### PR TITLE
Improve consistency of log messages

### DIFF
--- a/cmd/autoheal/healer.go
+++ b/cmd/autoheal/healer.go
@@ -178,7 +178,7 @@ func (h *Healer) Run(stopCh <-chan struct{}) error {
 		Build()
 
 	if err != nil {
-		glog.Warningf("Error building AWX Runner: %s", err)
+		glog.Warningf("Error building AWX runner: %s", err)
 	}
 
 	batchRunner, err := batchrunner.NewBuilder().
@@ -186,7 +186,7 @@ func (h *Healer) Run(stopCh <-chan struct{}) error {
 		Build()
 
 	if err != nil {
-		glog.Warningf("Error building Batch Runner: %s", err)
+		glog.Warningf("Error building batch runner: %s", err)
 	}
 
 	// initiailize runners.

--- a/cmd/autoheal/object_template.go
+++ b/cmd/autoheal/object_template.go
@@ -173,7 +173,7 @@ func (t *ObjectTemplate) processValue(input reflect.Value, data interface{}) (ou
 			output, err = t.processValue(reflect.ValueOf(output.Interface()), data)
 		default:
 			if glog.V(3) {
-				glog.Infof("Unsupported value kind: %v, skipping templating", output.Kind())
+				glog.Infof("Unsupported value kind '%s', skipping templating", output.Kind())
 			}
 		}
 	}

--- a/pkg/awxrunner/active_jobs_worker.go
+++ b/pkg/awxrunner/active_jobs_worker.go
@@ -24,7 +24,7 @@ import (
 )
 
 func (r *Runner) runActiveJobsWorker() {
-	glog.Infof("Going over active jobs queue.")
+	glog.Infof("Going over active jobs queue")
 
 	finishedJobs := make([]int, 0)
 
@@ -50,7 +50,7 @@ func (r *Runner) runActiveJobsWorker() {
 	// remove finished jobs from the queue
 	for _, job := range finishedJobs {
 		glog.Infof(
-			"Removing finished job `%v` from queue ",
+			"Removing finished job '%v' from queue ",
 			job,
 		)
 		r.activeJobs.Delete(job)

--- a/pkg/config/event_listener.go
+++ b/pkg/config/event_listener.go
@@ -21,7 +21,6 @@ package config
 import (
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/yaacov/observer/observer"
 )
 
@@ -47,7 +46,6 @@ type eventListener struct {
 func (e *eventListener) addChangeListener(listener ChangeListener) {
 	// add a new listener to configFilesChangedObserver
 	e.configFilesLoadedObserver.AddListener(func(_ interface{}) {
-		glog.Info("eventListener: Config object changed")
 		listener(&ChangeEvent{})
 	})
 }


### PR DESCRIPTION
This patch changes some of the log messages so that the general style is more consistent. In general a log message should be a grammatically correct sentence, starting with upper case and ending without punctuation. If values, like file names, are included then they should be enclosed in single quotes, so that it is
easy to spot unusual values like empty or blank strings:

```go
glog.Infof("Loading configuration from file '%s'", file)
```

When an error needs to be reported in the log message it should be included at the end of the message, after a colon:

```go
glog.Errorf("Can't load configuration file '%s': %s", file, err)
```
