### PR TITLE
Check config load errors

### DIFF
--- a/pkg/config/builder.go
+++ b/pkg/config/builder.go
@@ -109,8 +109,17 @@ func (b *Builder) Build() (c *Config, err error) {
 		loadMutex: &sync.Mutex{},
 	}
 
-	// Load and watch configuration files
-	c.watch()
+	// Do the initial load of the configuration files:
+	err = c.load()
+	if err != nil {
+		return
+	}
+
+	// Start watching the configuration files:
+	err = c.watch()
+	if err != nil {
+		return
+	}
 
 	return
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,21 +80,17 @@ func (c *Config) AddChangeListener(listener ChangeListener) {
 	c.listener.addChangeListener(listener)
 }
 
-// watch config files for changes
+// watch starts watching the configuration files.
 //
-func (c *Config) watch() {
+func (c *Config) watch() error {
 	e := c.listener
 	e.open()
-
-	// Load config files
-	c.load()
 
 	// Start watching config files for modifications.
 	configFiles := c.configFiles()
 	err := e.configFilesChangedObserver.Watch(configFiles)
 	if err != nil {
-		glog.Errorf("Can't watch configuration files: %s", err)
-		return
+		return err
 	}
 	for _, file := range configFiles {
 		glog.Infof("Watching configuration file '%s'", file)
@@ -113,6 +109,8 @@ func (c *Config) watch() {
 		// If config files loaded succesfully emit config object changed event.
 		e.configFilesLoadedObserver.Emit(observer.WatchEvent{Name: "Config loaded"})
 	})
+
+	return err
 }
 
 // load the configuration files and returns an error on fail.


### PR DESCRIPTION
Currently the errors that happen when initially loading the  configuration are ignored. For example, if the AWX credentials are  stored in a Kubernetes secret but the secret does not exist, or the connection to the API server does not work, the server will just continue using an empty user name and password. To avoid that this patch changes the code so that it explicitly checks for errors returned by the `load` method.