### PR TITLE
Check more errors when loading kubconfiig

### DIFF
--- a/pkg/config/builder_test.go
+++ b/pkg/config/builder_test.go
@@ -57,6 +57,10 @@ func TestFiles(t *testing.T) {
 
 	l.Files([]string{file0.Name(), file1.Name()})
 	cfg, err := l.Build()
+	if err != nil {
+		t.Errorf("An error occured! %s", err)
+	}
+	defer cfg.ShutDown()
 
 	expected := &Config{
 		awx: &AWXConfig{
@@ -298,23 +302,26 @@ func TestLoadFile(t *testing.T) {
 	l.File(file.Name())
 
 	for _, test := range configsTest {
-		file.WriteAt([]byte(test.configString), 0)
-		cfg, err := l.Build()
-		if err != nil {
-			t.Errorf("An error occured! %s", err)
-		}
+		func() {
+			file.WriteAt([]byte(test.configString), 0)
+			cfg, err := l.Build()
+			if err != nil {
+				t.Errorf("An error occured! %s", err)
+			}
+			defer cfg.ShutDown()
 
-		if !reflect.DeepEqual(cfg.awx, test.expected.awx) {
-			t.Errorf("Expected %+v but got %+v", test.expected.awx, cfg.awx)
-		}
+			if !reflect.DeepEqual(cfg.awx, test.expected.awx) {
+				t.Errorf("Expected %+v but got %+v", test.expected.awx, cfg.awx)
+			}
 
-		if !reflect.DeepEqual(cfg.throttling, test.expected.throttling) {
-			t.Errorf("Expected %+v but got %+v", test.expected.throttling, cfg.throttling)
-		}
+			if !reflect.DeepEqual(cfg.throttling, test.expected.throttling) {
+				t.Errorf("Expected %+v but got %+v", test.expected.throttling, cfg.throttling)
+			}
 
-		if !reflect.DeepEqual(cfg.rules.rules, test.expected.rules.rules) {
-			t.Errorf("Expected %+v but got %+v", test.expected.rules.rules, cfg.rules.rules)
-		}
+			if !reflect.DeepEqual(cfg.rules.rules, test.expected.rules.rules) {
+				t.Errorf("Expected %+v but got %+v", test.expected.rules.rules, cfg.rules.rules)
+			}
+		}()
 	}
 }
 
@@ -374,10 +381,10 @@ func TestLoadDir(t *testing.T) {
 	l.File(dir)
 
 	cfg, err := l.Build()
-
 	if err != nil {
 		t.Errorf("An error occured! %s", err)
 	}
+	defer cfg.ShutDown()
 
 	if !reflect.DeepEqual(cfg.awx, expected.awx) {
 		t.Errorf("Expected %+v but got %+v", expected.awx, cfg.awx)


### PR DESCRIPTION
**Description**

When loading kubeconfig we only check for `IsNotExist` error, other errors will get generic error message. This PR give specific error message for each type of file error. 

**Terminal dumps**

File does not exist:
```
14:52 $ _output/local/bin/linux/amd64/autoheal server --kubeconfig examples/autoheal-dev

I0509 14:52:08.806540    4687 server.go:144] Info: The Kubernetes configuration file 'examples/autoheal-dev' doesn't exist
I0509 14:52:08.806674    4687 server.go:148] Try to use the in-cluster configuration
F0509 14:52:08.806696    4687 server.go:153] Error loading in-cluster REST client configuration: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
```

File is not a config file:
```
14:52 $ _output/local/bin/linux/amd64/autoheal server --kubeconfig examples/autoheal-dev.yml 

F0509 14:52:22.328359    4744 server.go:138] Error loading REST client configuration from file 'examples/autoheal-dev.yml': invalid configuration: no configuration has been provided
```

File is a directory:
```
14:52 $ _output/local/bin/linux/amd64/autoheal server --kubeconfig examples

F0509 14:52:35.216649    4802 server.go:157] Error: The Kubernetes configuration path 'examples' is a direcory
```

Default file is not exist:
```
14:52 $ mv ~/.kube/config ~/.kube/config.old
14:53 $ _output/local/bin/linux/amd64/autoheal server

I0509 14:53:19.247959    4986 server.go:144] Info: The Kubernetes configuration file '/home/yzamir/.kube/config' doesn't exist
I0509 14:53:19.248039    4986 server.go:148] Try to use the in-cluster configuration
F0509 14:53:19.248055    4986 server.go:153] Error loading in-cluster REST client configuration: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
```

Default file exist:
```
14:53 $ mv ~/.kube/config.old ~/.kube/config
14:53 $ _output/local/bin/linux/amd64/autoheal server

I0509 14:53:32.269368    5093 config.go:193] Loading configuration file 'autoheal.yml'
...
```

Fix: https://github.com/openshift/autoheal/issues/14
Reference: https://kubernetes-v1-4.github.io/docs/user-guide/kubectl/kubectl_config/