### PR TITLE
Check prompt-on-launch before launching a job

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -109,8 +109,8 @@
     "awx",
     "awx/internal/data"
   ]
-  revision = "78fe047d29a6a1fdcf7f5f0d9487706a1784b2e2"
-  version = "0.0.3"
+  revision = "5c5af1820763b6c2767f9c92fd7a3a8fe71668ff"
+  version = "0.0.4"
 
 [[projects]]
   name = "github.com/openshift/origin"
@@ -446,6 +446,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7f9b808836d9b49152c3d3c41374118baa8ab7cda1f482fe9883eedeb786e75a"
+  inputs-digest = "0a0b4f4262958a9d6b4a021acadf419581cf869945a8955d4255cc27243b257d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -63,7 +63,7 @@ required = [
 
 [[constraint]]
   name = "github.com/moolitayer/awx-client-go"
-  version = "=0.0.3"
+  version = "=0.0.4"
 
 [[constraint]]
   name = "github.com/spf13/cobra"

--- a/pkg/awxrunner/awx_action_runner.go
+++ b/pkg/awxrunner/awx_action_runner.go
@@ -139,6 +139,19 @@ func (r *Runner) launchAWXJob(
 ) error {
 	templateId := template.Id()
 	templateName := template.Name()
+
+	// Verify limit prompt on launch
+	if action.Limit != "" && !template.AskLimitOnLaunch() {
+		glog.Warningf("About to launch template '%s' with limit '%s', but 'prompt-on-launch' is false. Limit will be ignored",
+			templateName, action.Limit)
+	}
+
+	// Verify extra-vars prompt on launch
+	if action.ExtraVars != nil && !template.AskVarsOnLaunch() {
+		glog.Warningf("About to launch template '%s' with extra-vars, but 'prompt-on-launch' is false. Extra Variables will be ignored",
+			templateName)
+	}
+
 	launchResource := connection.JobTemplates().Id(templateId).Launch()
 	response, err := launchResource.Post().
 		ExtraVars(action.ExtraVars).

--- a/vendor/github.com/moolitayer/awx-client-go/awx/internal/data/job_template.go
+++ b/vendor/github.com/moolitayer/awx-client-go/awx/internal/data/job_template.go
@@ -19,8 +19,10 @@ limitations under the License.
 package data
 
 type JobTemplate struct {
-	Id   int    `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
+	Id               int    `json:"id,omitempty"`
+	Name             string `json:"name,omitempty"`
+	AskLimitOnLaunch bool   `json:"ask_limit_on_launch,omitempty"`
+	AskVarsOnLaunch  bool   `json:"ask_variables_on_launch,omitempty"`
 }
 
 type JobTemplateGetResponse struct {

--- a/vendor/github.com/moolitayer/awx-client-go/awx/job_template.go
+++ b/vendor/github.com/moolitayer/awx-client-go/awx/job_template.go
@@ -19,8 +19,10 @@ limitations under the License.
 package awx
 
 type JobTemplate struct {
-	id   int
-	name string
+	id               int
+	name             string
+	askLimitOnLaunch bool
+	askVarsOnLaunch  bool
 }
 
 func (t *JobTemplate) Id() int {
@@ -29,4 +31,12 @@ func (t *JobTemplate) Id() int {
 
 func (t *JobTemplate) Name() string {
 	return t.name
+}
+
+func (t *JobTemplate) AskLimitOnLaunch() bool {
+	return t.askLimitOnLaunch
+}
+
+func (t *JobTemplate) AskVarsOnLaunch() bool {
+	return t.askVarsOnLaunch
 }

--- a/vendor/github.com/moolitayer/awx-client-go/awx/job_template_resource.go
+++ b/vendor/github.com/moolitayer/awx-client-go/awx/job_template_resource.go
@@ -58,6 +58,9 @@ func (r *JobTemplateGetRequest) Send() (response *JobTemplateGetResponse, err er
 	response.result = new(JobTemplate)
 	response.result.id = output.Id
 	response.result.name = output.Name
+	response.result.askLimitOnLaunch = output.AskLimitOnLaunch
+	response.result.askVarsOnLaunch = output.AskVarsOnLaunch
+
 	return
 }
 

--- a/vendor/github.com/moolitayer/awx-client-go/awx/job_templates_resource.go
+++ b/vendor/github.com/moolitayer/awx-client-go/awx/job_templates_resource.go
@@ -70,6 +70,8 @@ func (r *JobTemplatesGetRequest) Send() (response *JobTemplatesGetResponse, err 
 		response.results[i] = new(JobTemplate)
 		response.results[i].id = output.Results[i].Id
 		response.results[i].name = output.Results[i].Name
+		response.results[i].askLimitOnLaunch = output.Results[i].AskLimitOnLaunch
+		response.results[i].askVarsOnLaunch = output.Results[i].AskVarsOnLaunch
 	}
 	return
 }


### PR DESCRIPTION
Add a check that `PROMPT ON LAUNCH` is set for limit and extra-vars in case they aren't empty.
If limit/extra-vars are configured, but the template doesn't have prompt-on-launch set for them, log a user warning.

fix #89 

![prompt_on_launch](https://user-images.githubusercontent.com/20948594/39966116-2e4a6ea6-56af-11e8-8536-52960dd2a8a1.png)
