### PR TITLE
Example config: clarify what keys credentialsRef secret should have

### DIFF
--- a/autoheal.yml
+++ b/autoheal.yml
@@ -34,8 +34,8 @@ awx:
   proxy: http://my-proxy.example.com:3128
 
   #
-  # Reference to the Kubernetes secret that contains the user name and password
-  # to use to connect to the AWX API.
+  # Reference to the Kubernetes secret expected to contain "username" and
+  # "password" keys to use to connect to the AWX API.
   #
   credentialsRef:
     namespace: my-namespace


### PR DESCRIPTION
This is already documented in README but won't hurt in example config too.