### PR TITLE
Add a Dockerfile for simple build from source, not through rpms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,11 @@ RUN apk --no-cache add ca-certificates
 RUN useradd --no-create-home autoheal
 USER autoheal
 EXPOSE 9099
-WORKDIR /root/
+
+WORKDIR /bin
 COPY --from=builder /go/src/github.com/openshift/autoheal/_output/local/bin/linux/amd64/autoheal .
-CMD ["./autoheal"]
 
 LABEL io.k8s.display-name="OpenShift Autoheal"
 LABEL io.k8s.description="OpenShift Autoheal"
 LABEL io.openshift.tags="openshift"
+CMD ["./autoheal"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,7 @@ RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/openshift/autoheal/_output/local/bin/linux/amd64/autoheal .
 CMD ["./autoheal"]
+
+LABEL io.k8s.display-name="OpenShift Autoheal"
+LABEL io.k8s.description="OpenShift Autoheal"
+LABEL io.openshift.tags="openshift"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ RUN hack/build-go.sh
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
+
+RUN useradd --no-create-home autoheal
+USER autoheal
+EXPOSE 9099
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/openshift/autoheal/_output/local/bin/linux/amd64/autoheal .
 CMD ["./autoheal"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# Development build from source.
+# See images/autoheal/Dockerfile for downstream build from rpms.
+
 FROM golang:1.10 as builder
 WORKDIR /go/src/github.com/openshift/autoheal/
 COPY . .
@@ -15,4 +18,4 @@ COPY --from=builder /go/src/github.com/openshift/autoheal/_output/local/bin/linu
 LABEL io.k8s.display-name="OpenShift Autoheal"
 LABEL io.k8s.description="OpenShift Autoheal"
 LABEL io.openshift.tags="openshift"
-CMD ["./autoheal"]
+ENTRYPOINT ./autoheal

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ WORKDIR /go/src/github.com/openshift/autoheal/
 COPY . .
 RUN hack/build-go.sh
 
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+FROM centos:7
 
 RUN useradd --no-create-home autoheal
 USER autoheal

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.10 as builder
+WORKDIR /go/src/github.com/openshift/autoheal/
+COPY . .
+RUN hack/build-go.sh
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/openshift/autoheal/_output/local/bin/linux/amd64/autoheal .
+CMD ["./autoheal"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/autoheal/
 COPY . .
 RUN hack/build-go.sh
 
-FROM scratch
+FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/openshift/autoheal/_output/local/bin/linux/amd64/autoheal .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/autoheal/
 COPY . .
 RUN hack/build-go.sh
 
-FROM alpine:latest
+FROM scratch
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/openshift/autoheal/_output/local/bin/linux/amd64/autoheal .


### PR DESCRIPTION
I just want to run it, using openshift-ansible, so I need an image :-)
The default image specified by openshift-ansible doesn't exist.
`make build-rpms build-images` doesn't work for me as I don't have `imagebuilder`.

This uses a multi-stage build which requires docker 17.05 or higher, not available in fedora yet, works fine on Quay (probably Docker Hub too, untested).
https://quay.io/repository/cben/autoheal
`docker pull quay.io/cben/autoheal:dockerfile`