### PR TITLE
Try to `go get` imagebuilder if not installed

### DIFF
--- a/hack/build-images.sh
+++ b/hack/build-images.sh
@@ -15,7 +15,7 @@ function cleanup() {
 }
 trap "cleanup" EXIT
 
-os::util::ensure::gopath_binary_exists imagebuilder
+os::util::ensure::gopath_binary_exists imagebuilder github.com/openshift/imagebuilder/cmd/imagebuilder
 # image builds require RPMs to have been built
 os::build::release::check_for_rpms
 


### PR DESCRIPTION
This is what was stopping me from `make build-images` working :-)

Uses optional `go get` ability of `os::util::ensure::gopath_binary_exists`.